### PR TITLE
Add Bitcoin price dashboard demo

### DIFF
--- a/src/pages/bitcoin-dashboard/app.tsx
+++ b/src/pages/bitcoin-dashboard/app.tsx
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { Content } from './components/content';
+import { DashboardHeader } from './components/header';
+import { DashboardSideNavigation } from './components/side-navigation';
+import { BitcoinDashboardInfo } from './components/dashboard-info';
+import { useBitcoinPrice } from './hooks/use-bitcoin-price';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <BitcoinDashboardInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const { priceData, loading, error, priceHistory, refreshPriceData } = useBitcoinPrice();
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <DashboardHeader
+              onRefresh={refreshPriceData}
+              loading={loading}
+              lastUpdated={priceData?.time.updatedISO || null}
+            />
+            <Content priceData={priceData} loading={loading} error={error} priceHistory={priceHistory} />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Bitcoin Price Dashboard', href: '#/' }]} />}
+        navigation={<DashboardSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/bitcoin-dashboard/components/content.tsx
+++ b/src/pages/bitcoin-dashboard/components/content.tsx
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Alert from '@cloudscape-design/components/alert';
+import Grid from '@cloudscape-design/components/grid';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { BitcoinPriceResponse, PriceHistory } from '../types';
+import { PriceCard } from './price-card';
+import { PriceHistoryTable } from './price-history-table';
+import { PriceChart } from './price-chart';
+
+interface ContentProps {
+  priceData: BitcoinPriceResponse | null;
+  loading: boolean;
+  error: string | null;
+  priceHistory: PriceHistory[];
+}
+
+export function Content({ priceData, loading, error, priceHistory }: ContentProps) {
+  if (error) {
+    return (
+      <Alert type="error" header="Error fetching Bitcoin price data">
+        {error}
+      </Alert>
+    );
+  }
+
+  if (loading && !priceData) {
+    return (
+      <Alert type="info" header="Loading Bitcoin price data">
+        Please wait while we fetch the latest Bitcoin prices...
+      </Alert>
+    );
+  }
+
+  if (!priceData) {
+    return (
+      <Alert type="warning" header="No price data available">
+        No Bitcoin price data is currently available. Please try refreshing the page.
+      </Alert>
+    );
+  }
+
+  const lastUpdated = priceData.time.updatedISO;
+
+  return (
+    <SpaceBetween size="l">
+      {/* Currency Price Cards */}
+      <Grid
+        gridDefinition={[
+          { colspan: { xl: 4, l: 4, m: 4, s: 12, xs: 12, default: 12 } },
+          { colspan: { xl: 4, l: 4, m: 4, s: 12, xs: 12, default: 12 } },
+          { colspan: { xl: 4, l: 4, m: 4, s: 12, xs: 12, default: 12 } },
+        ]}
+      >
+        <PriceCard currencyCode="USD" data={priceData.bpi.USD} lastUpdated={lastUpdated} />
+        <PriceCard currencyCode="GBP" data={priceData.bpi.GBP} lastUpdated={lastUpdated} />
+        <PriceCard currencyCode="EUR" data={priceData.bpi.EUR} lastUpdated={lastUpdated} />
+      </Grid>
+
+      {/* Price Chart */}
+      <PriceChart priceHistory={priceHistory} />
+
+      {/* Price History Table */}
+      <PriceHistoryTable priceHistory={priceHistory} />
+
+      {/* Attribution */}
+      <div style={{ textAlign: 'center', fontSize: '0.8rem', color: '#666' }}>{priceData.disclaimer}</div>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/bitcoin-dashboard/components/dashboard-info.tsx
+++ b/src/pages/bitcoin-dashboard/components/dashboard-info.tsx
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Link from '@cloudscape-design/components/link';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+export function BitcoinDashboardInfo() {
+  return (
+    <div>
+      <Box variant="h2">Bitcoin Price Dashboard</Box>
+      <p>This dashboard displays real-time Bitcoin price data from the CoinDesk Bitcoin Price Index (BPI).</p>
+
+      <h3>Features:</h3>
+      <ul>
+        <li>Real-time Bitcoin prices in USD, GBP, and EUR</li>
+        <li>Historical price tracking during the session</li>
+        <li>Price chart visualization</li>
+        <li>Auto-refresh every 60 seconds</li>
+      </ul>
+
+      <h3>API Information:</h3>
+      <p>
+        This demo uses the CoinDesk Bitcoin Price Index API. The BPI is a simple price index that averages the price of
+        Bitcoin across leading global exchanges.
+      </p>
+
+      <SpaceBetween size="s">
+        <Link external href="https://api.coindesk.com/v1/bpi/currentprice.json">
+          View Raw API Data
+        </Link>
+
+        <Link external href="https://www.coindesk.com/price/bitcoin">
+          Visit CoinDesk for More Information
+        </Link>
+      </SpaceBetween>
+
+      <Box variant="small" padding={{ top: 'l' }}>
+        <i>Powered by CoinDesk</i>
+      </Box>
+    </div>
+  );
+}

--- a/src/pages/bitcoin-dashboard/components/header.tsx
+++ b/src/pages/bitcoin-dashboard/components/header.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+interface DashboardHeaderProps {
+  onRefresh: () => void;
+  loading: boolean;
+  lastUpdated: string | null;
+}
+
+export function DashboardHeader({ onRefresh, loading, lastUpdated }: DashboardHeaderProps) {
+  // Format the last update time
+  const formattedTime = lastUpdated ? new Date(lastUpdated).toLocaleTimeString() : 'Never';
+
+  return (
+    <Header
+      variant="h1"
+      actions={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button onClick={onRefresh} loading={loading}>
+            Refresh
+          </Button>
+        </SpaceBetween>
+      }
+      description="Real-time Bitcoin price data from the CoinDesk Bitcoin Price Index (BPI)."
+      info={
+        <Box color="text-body-secondary" fontSize="body-s">
+          Last updated: {formattedTime}
+        </Box>
+      }
+    >
+      Bitcoin Price Dashboard
+    </Header>
+  );
+}

--- a/src/pages/bitcoin-dashboard/components/price-card.tsx
+++ b/src/pages/bitcoin-dashboard/components/price-card.tsx
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { CurrencyData } from '../types';
+
+interface PriceCardProps {
+  currencyCode: string;
+  data: CurrencyData;
+  lastUpdated: string;
+}
+
+export function PriceCard({ currencyCode, data, lastUpdated }: PriceCardProps) {
+  // Format the rate as a currency with the specific currency symbol
+  const formattedPrice = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currencyCode,
+    maximumFractionDigits: 2,
+  }).format(data.rate_float);
+
+  // Calculate time elapsed since last update
+  const lastUpdateTime = new Date(lastUpdated);
+  const now = new Date();
+  const secondsElapsed = Math.floor((now.getTime() - lastUpdateTime.getTime()) / 1000);
+
+  let updateStatus;
+  if (secondsElapsed < 30) {
+    updateStatus = <StatusIndicator type="success">Updated just now</StatusIndicator>;
+  } else if (secondsElapsed < 120) {
+    updateStatus = <StatusIndicator type="success">Updated {secondsElapsed} seconds ago</StatusIndicator>;
+  } else if (secondsElapsed < 300) {
+    updateStatus = <StatusIndicator type="info">Updated {Math.floor(secondsElapsed / 60)} minutes ago</StatusIndicator>;
+  } else {
+    updateStatus = (
+      <StatusIndicator type="warning">Updated {Math.floor(secondsElapsed / 60)} minutes ago</StatusIndicator>
+    );
+  }
+
+  return (
+    <Container header={<Header variant="h2">Bitcoin Price ({currencyCode})</Header>}>
+      <SpaceBetween size="m">
+        <Box variant="h1" textAlign="center" padding="l">
+          {formattedPrice}
+        </Box>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <Box variant="small" color="text-body-secondary">
+              {data.description}
+            </Box>
+          </div>
+          <div>{updateStatus}</div>
+        </div>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/bitcoin-dashboard/components/price-chart.tsx
+++ b/src/pages/bitcoin-dashboard/components/price-chart.tsx
@@ -1,0 +1,178 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SegmentedControl from '@cloudscape-design/components/segmented-control';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { PriceHistory } from '../types';
+
+interface PriceChartProps {
+  priceHistory: PriceHistory[];
+}
+
+export function PriceChart({ priceHistory }: PriceChartProps) {
+  const [selectedCurrency, setSelectedCurrency] = useState<string>('USD');
+
+  // Get unique currencies from history
+  const currencies = Array.from(new Set(priceHistory.map(item => item.currency)));
+
+  // Filter history by selected currency and sort by timestamp (oldest first)
+  const filteredHistory = priceHistory
+    .filter(item => item.currency === selectedCurrency)
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+  // Prepare chart data
+  const chartData = filteredHistory.map(item => ({
+    timestamp: new Date(item.timestamp).getTime(),
+    price: item.price,
+  }));
+
+  // Find min and max prices for y-axis scaling
+  const prices = chartData.map(item => item.price);
+  const minPrice = Math.min(...prices) * 0.995; // Add 0.5% padding
+  const maxPrice = Math.max(...prices) * 1.005; // Add 0.5% padding
+
+  // Canvas dimensions
+  const width = 900;
+  const height = 300;
+  const padding = { top: 20, right: 20, bottom: 30, left: 80 };
+
+  // Convert data point to x,y coordinates
+  const getX = (timestamp: number) => {
+    if (chartData.length <= 1) return padding.left;
+    const minTime = chartData[0].timestamp;
+    const maxTime = chartData[chartData.length - 1].timestamp;
+    const timeRange = maxTime - minTime;
+    return padding.left + ((timestamp - minTime) / timeRange) * (width - padding.left - padding.right);
+  };
+
+  const getY = (price: number) => {
+    if (maxPrice === minPrice) return height / 2; // Center if no range
+    return (
+      height - padding.bottom - ((price - minPrice) / (maxPrice - minPrice)) * (height - padding.top - padding.bottom)
+    );
+  };
+
+  // Generate path for the line
+  const generateLinePath = () => {
+    if (chartData.length === 0) return '';
+
+    return chartData.reduce((path, point, index) => {
+      const command = index === 0 ? 'M' : 'L';
+      return path + `${command}${getX(point.timestamp)},${getY(point.price)} `;
+    }, '');
+  };
+
+  // Format price for y-axis
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: selectedCurrency,
+      maximumFractionDigits: 0,
+    }).format(price);
+  };
+
+  // Generate y-axis ticks
+  const generateYTicks = () => {
+    const tickCount = 5;
+    const ticks = [];
+
+    for (let i = 0; i < tickCount; i++) {
+      const price = minPrice + (i / (tickCount - 1)) * (maxPrice - minPrice);
+      ticks.push(price);
+    }
+
+    return ticks;
+  };
+
+  const yTicks = generateYTicks();
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          actions={
+            <SegmentedControl
+              selectedId={selectedCurrency}
+              onChange={({ detail }) => setSelectedCurrency(detail.selectedId)}
+              options={currencies.map(currency => ({ id: currency, text: currency }))}
+            />
+          }
+        >
+          Bitcoin Price Trend
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {priceHistory.length === 0 ? (
+          <Box textAlign="center" padding="l">
+            Waiting for price data...
+          </Box>
+        ) : (
+          <div>
+            <svg width={width} height={height} style={{ overflow: 'visible' }}>
+              {/* X and Y axes */}
+              <line
+                x1={padding.left}
+                y1={height - padding.bottom}
+                x2={width - padding.right}
+                y2={height - padding.bottom}
+                stroke="#cccccc"
+                strokeWidth={1}
+              />
+              <line
+                x1={padding.left}
+                y1={padding.top}
+                x2={padding.left}
+                y2={height - padding.bottom}
+                stroke="#cccccc"
+                strokeWidth={1}
+              />
+
+              {/* Y-axis ticks and labels */}
+              {yTicks.map((tick, index) => (
+                <React.Fragment key={index}>
+                  <line
+                    x1={padding.left - 5}
+                    y1={getY(tick)}
+                    x2={padding.left}
+                    y2={getY(tick)}
+                    stroke="#cccccc"
+                    strokeWidth={1}
+                  />
+                  <text
+                    x={padding.left - 10}
+                    y={getY(tick)}
+                    textAnchor="end"
+                    dominantBaseline="middle"
+                    fontSize={12}
+                    fill="#666666"
+                  >
+                    {formatPrice(tick)}
+                  </text>
+                </React.Fragment>
+              ))}
+
+              {/* Line chart */}
+              <path d={generateLinePath()} fill="none" stroke="#0073bb" strokeWidth={2} />
+
+              {/* Data points */}
+              {chartData.map((point, index) => (
+                <circle key={index} cx={getX(point.timestamp)} cy={getY(point.price)} r={3} fill="#0073bb" />
+              ))}
+            </svg>
+
+            <Box textAlign="center" padding="s" fontSize="body-s" color="text-body-secondary">
+              Price chart shows data points collected during this session
+            </Box>
+          </div>
+        )}
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/bitcoin-dashboard/components/price-history-table.tsx
+++ b/src/pages/bitcoin-dashboard/components/price-history-table.tsx
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Pagination from '@cloudscape-design/components/pagination';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+import TextFilter from '@cloudscape-design/components/text-filter';
+
+import { PriceHistory } from '../types';
+
+interface PriceHistoryTableProps {
+  priceHistory: PriceHistory[];
+}
+
+export function PriceHistoryTable({ priceHistory }: PriceHistoryTableProps) {
+  const [filterText, setFilterText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+
+  const itemsPerPage = 10;
+
+  const filteredItems = priceHistory.filter(
+    item => filterText === '' || item.currency.toLowerCase().includes(filterText.toLowerCase()),
+  );
+
+  // Calculate pagination
+  const pagesCount = Math.ceil(filteredItems.length / itemsPerPage);
+  const startIndex = (currentPageIndex - 1) * itemsPerPage;
+  const displayedItems = filteredItems.slice(startIndex, startIndex + itemsPerPage);
+
+  // Format timestamp for display
+  const formatTimestamp = (timestamp: string) => {
+    const date = new Date(timestamp);
+    return date.toLocaleString();
+  };
+
+  // Format price for display
+  const formatPrice = (price: number, currency: string) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+      maximumFractionDigits: 2,
+    }).format(price);
+  };
+
+  return (
+    <Table
+      columnDefinitions={[
+        {
+          id: 'timestamp',
+          header: 'Time',
+          cell: item => formatTimestamp(item.timestamp),
+          sortingField: 'timestamp',
+        },
+        {
+          id: 'currency',
+          header: 'Currency',
+          cell: item => item.currency,
+          sortingField: 'currency',
+        },
+        {
+          id: 'price',
+          header: 'Price',
+          cell: item => formatPrice(item.price, item.currency),
+          sortingField: 'price',
+        },
+      ]}
+      items={displayedItems}
+      sortingDisabled={false}
+      trackBy="timestamp"
+      empty={
+        <Box textAlign="center" padding="l">
+          <SpaceBetween size="xs" direction="vertical" alignItems="center">
+            <Box variant="h3">No price history</Box>
+            <Box variant="p">Price history will appear after refreshing the data.</Box>
+          </SpaceBetween>
+        </Box>
+      }
+      filter={
+        <TextFilter
+          filteringText={filterText}
+          filteringPlaceholder="Filter by currency"
+          filteringAriaLabel="Filter price history"
+          onChange={({ detail }) => setFilterText(detail.filteringText)}
+        />
+      }
+      pagination={
+        <Pagination
+          currentPageIndex={currentPageIndex}
+          pagesCount={pagesCount}
+          onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+        />
+      }
+      header={
+        <Box padding="s" textAlign="center">
+          <h2>Price History</h2>
+        </Box>
+      }
+    />
+  );
+}

--- a/src/pages/bitcoin-dashboard/components/side-navigation.tsx
+++ b/src/pages/bitcoin-dashboard/components/side-navigation.tsx
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation from '@cloudscape-design/components/side-navigation';
+
+export function DashboardSideNavigation() {
+  return (
+    <SideNavigation
+      activeHref="#/bitcoin"
+      header={{ text: 'Bitcoin Price Demo', href: '#/' }}
+      items={[
+        { type: 'link', text: 'Dashboard', href: '#/bitcoin' },
+        { type: 'divider' },
+        {
+          type: 'link',
+          text: 'CoinDesk',
+          href: 'https://www.coindesk.com/price/bitcoin',
+          external: true,
+        },
+        {
+          type: 'link',
+          text: 'API Documentation',
+          href: 'https://www.coindesk.com/coindesk-api',
+          external: true,
+        },
+      ]}
+    />
+  );
+}

--- a/src/pages/bitcoin-dashboard/hooks/use-bitcoin-price.ts
+++ b/src/pages/bitcoin-dashboard/hooks/use-bitcoin-price.ts
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { useState, useEffect, useCallback } from 'react';
+import { BitcoinPriceResponse, PriceHistory } from '../types';
+
+const API_URL = 'https://api.coindesk.com/v1/bpi/currentprice.json';
+
+export function useBitcoinPrice() {
+  const [priceData, setPriceData] = useState<BitcoinPriceResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [priceHistory, setPriceHistory] = useState<PriceHistory[]>([]);
+
+  const fetchBitcoinPrice = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await fetch(API_URL);
+
+      if (!response.ok) {
+        throw new Error(`API response error: ${response.status}`);
+      }
+
+      const data: BitcoinPriceResponse = await response.json();
+      setPriceData(data);
+
+      // Add current prices to history
+      const now = new Date().toISOString();
+      setPriceHistory(prevHistory => {
+        // Keep only the last 20 entries for each currency
+        const newHistory = [...prevHistory];
+
+        // Add new entries for each currency
+        Object.entries(data.bpi).forEach(([currency, details]) => {
+          newHistory.push({
+            currency,
+            timestamp: now,
+            price: details.rate_float,
+          });
+        });
+
+        // Sort by timestamp (newest first) and limit to 100 entries
+        return newHistory
+          .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+          .slice(0, 100);
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch Bitcoin price data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Fetch price data on initial load
+  useEffect(() => {
+    fetchBitcoinPrice();
+
+    // Set up polling every 60 seconds
+    const intervalId = setInterval(() => {
+      fetchBitcoinPrice();
+    }, 60000);
+
+    // Clear interval on component unmount
+    return () => clearInterval(intervalId);
+  }, [fetchBitcoinPrice]);
+
+  return {
+    priceData,
+    loading,
+    error,
+    priceHistory,
+    refreshPriceData: fetchBitcoinPrice,
+  };
+}

--- a/src/pages/bitcoin-dashboard/index.tsx
+++ b/src/pages/bitcoin-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function BitcoinDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/bitcoin-dashboard/types.ts
+++ b/src/pages/bitcoin-dashboard/types.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface CurrencyData {
+  code: string;
+  symbol: string;
+  rate: string;
+  description: string;
+  rate_float: number;
+}
+
+export interface BitcoinPriceIndex {
+  USD: CurrencyData;
+  GBP: CurrencyData;
+  EUR: CurrencyData;
+}
+
+export interface BitcoinPriceResponse {
+  time: {
+    updated: string;
+    updatedISO: string;
+    updateduk: string;
+  };
+  disclaimer: string;
+  chartName: string;
+  bpi: BitcoinPriceIndex;
+}
+
+export interface PriceHistory {
+  currency: string;
+  timestamp: string;
+  price: number;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,34 +23,115 @@ import Link from '@cloudscape-design/components/link';
 const demos = [
   { route: '/cards', title: 'Card View', description: 'Demo of Cloudscape Cards component.', category: 'Components' },
   { route: '/chat', title: 'Chat', description: 'Chat UI demo.', category: 'Applications' },
-  { route: '/configurable-dashboard', title: 'Configurable Dashboard', description: 'Dashboard with configurable widgets.', category: 'Dashboards' },
+  {
+    route: '/configurable-dashboard',
+    title: 'Configurable Dashboard',
+    description: 'Dashboard with configurable widgets.',
+    category: 'Dashboards',
+  },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
-  { route: '/delete-one-click', title: 'One-click Delete', description: 'Delete with a single click.', category: 'Forms' },
-  { route: '/delete-with-additional-confirmation', title: 'Delete with Additional Confirmation', description: 'Delete with extra confirmation step.', category: 'Forms' },
-  { route: '/delete-with-simple-confirmation', title: 'Delete with Simple Confirmation', description: 'Delete with simple confirmation.', category: 'Forms' },
+  {
+    route: '/random-user-dashboard',
+    title: 'Random User Dashboard',
+    description: 'Table view of users from randomuser.me API.',
+    category: 'Dashboards',
+  },
+  {
+    route: '/delete-one-click',
+    title: 'One-click Delete',
+    description: 'Delete with a single click.',
+    category: 'Forms',
+  },
+  {
+    route: '/delete-with-additional-confirmation',
+    title: 'Delete with Additional Confirmation',
+    description: 'Delete with extra confirmation step.',
+    category: 'Forms',
+  },
+  {
+    route: '/delete-with-simple-confirmation',
+    title: 'Delete with Simple Confirmation',
+    description: 'Delete with simple confirmation.',
+    category: 'Forms',
+  },
   { route: '/details', title: 'Details Page', description: 'Resource details page.', category: 'Details' },
   { route: '/details-hub', title: 'Details Hub', description: 'Details page as a hub.', category: 'Details' },
   { route: '/details-tabs', title: 'Details with Tabs', description: 'Details page with tabs.', category: 'Details' },
   { route: '/edit', title: 'Edit Resource', description: 'Edit resource demo.', category: 'Forms' },
   { route: '/form', title: 'Single Page Create', description: 'Single page form demo.', category: 'Forms' },
-  { route: '/form-unsaved-changes', title: 'Unsaved Changes', description: 'Communicate unsaved changes.', category: 'Forms' },
+  {
+    route: '/form-unsaved-changes',
+    title: 'Unsaved Changes',
+    description: 'Communicate unsaved changes.',
+    category: 'Forms',
+  },
   { route: '/form-validation', title: 'Form Validation', description: 'Form validation demo.', category: 'Forms' },
   { route: '/manage-tags', title: 'Manage Tags', description: 'Tag management demo.', category: 'Components' },
-  { route: '/non-console', title: 'Top Navigation', description: 'Non-console top navigation.', category: 'Navigation' },
+  {
+    route: '/non-console',
+    title: 'Top Navigation',
+    description: 'Non-console top navigation.',
+    category: 'Navigation',
+  },
   { route: '/onboarding', title: 'Onboarding', description: 'Hands-on tutorials.', category: 'Onboarding' },
-  { route: '/product-detail-page', title: 'Product Detail Page', description: 'Product details demo.', category: 'Applications' },
+  {
+    route: '/product-detail-page',
+    title: 'Product Detail Page',
+    description: 'Product details demo.',
+    category: 'Applications',
+  },
   { route: '/read-from-s3', title: 'Read from S3', description: 'Read data from Amazon S3.', category: 'Integration' },
-  { route: '/server-side-table', title: 'Server-side Table', description: 'Table view (server-side).', category: 'Tables' },
-  { route: '/server-side-table-property-filter', title: 'Server-side Table Property Filter', description: 'Table property filter (server-side).', category: 'Tables' },
-  { route: '/split-panel-comparison', title: 'Split Panel Comparison', description: 'Split view with details comparison.', category: 'Panels' },
+  {
+    route: '/server-side-table',
+    title: 'Server-side Table',
+    description: 'Table view (server-side).',
+    category: 'Tables',
+  },
+  {
+    route: '/server-side-table-property-filter',
+    title: 'Server-side Table Property Filter',
+    description: 'Table property filter (server-side).',
+    category: 'Tables',
+  },
+  {
+    route: '/split-panel-comparison',
+    title: 'Split Panel Comparison',
+    description: 'Split view with details comparison.',
+    category: 'Panels',
+  },
   { route: '/split-panel-multiple', title: 'Split Panel Multiple', description: 'Split view.', category: 'Panels' },
   { route: '/table', title: 'Table View', description: 'Demo of Cloudscape Table component.', category: 'Tables' },
-  { route: '/table-date-filter', title: 'Table Date Filter', description: 'Table with date range picker filter.', category: 'Tables' },
+  {
+    route: '/table-date-filter',
+    title: 'Table Date Filter',
+    description: 'Table with date range picker filter.',
+    category: 'Tables',
+  },
   { route: '/table-editable', title: 'Editable Table', description: 'Table with inline editing.', category: 'Tables' },
-  { route: '/table-expandable', title: 'Expandable Table', description: 'Table with expandable rows.', category: 'Tables' },
-  { route: '/table-property-filter', title: 'Table Property Filter', description: 'Table with property filter.', category: 'Tables' },
-  { route: '/table-saved-filters', title: 'Table Saved Filters', description: 'Table with saved filter sets.', category: 'Tables' },
-  { route: '/table-select-filter', title: 'Table Select Filter', description: 'Table with select filter.', category: 'Tables' },
+  {
+    route: '/table-expandable',
+    title: 'Expandable Table',
+    description: 'Table with expandable rows.',
+    category: 'Tables',
+  },
+  {
+    route: '/table-property-filter',
+    title: 'Table Property Filter',
+    description: 'Table with property filter.',
+    category: 'Tables',
+  },
+  {
+    route: '/table-saved-filters',
+    title: 'Table Saved Filters',
+    description: 'Table with saved filter sets.',
+    category: 'Tables',
+  },
+  {
+    route: '/table-select-filter',
+    title: 'Table Select Filter',
+    description: 'Table with select filter.',
+    category: 'Tables',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];
@@ -67,17 +148,14 @@ export default function Home() {
 
   // Filter demos based on filter text and selected category
   const filteredDemos = demos.filter(
-    demo => 
+    demo =>
       (demo.title.toLowerCase().includes(filterText.toLowerCase()) ||
-       demo.description.toLowerCase().includes(filterText.toLowerCase())) &&
-      (selectedCategory === 'All' || demo.category === selectedCategory)
+        demo.description.toLowerCase().includes(filterText.toLowerCase())) &&
+      (selectedCategory === 'All' || demo.category === selectedCategory),
   );
 
   // Paginate the filtered demos
-  const paginatedDemos = filteredDemos.slice(
-    (currentPageIndex - 1) * itemsPerPage,
-    currentPageIndex * itemsPerPage
-  );
+  const paginatedDemos = filteredDemos.slice((currentPageIndex - 1) * itemsPerPage, currentPageIndex * itemsPerPage);
 
   return (
     <AppLayout
@@ -104,12 +182,13 @@ export default function Home() {
               <Flashbar
                 items={[
                   {
-                    type: "info",
-                    content: "Welcome to the Cloudscape Design System demo collection. These patterns and components showcase modern cloud application experiences.",
+                    type: 'info',
+                    content:
+                      'Welcome to the Cloudscape Design System demo collection. These patterns and components showcase modern cloud application experiences.',
                     dismissible: true,
-                    buttonText: "Learn more",
-                    onButtonClick: () => window.open("https://cloudscape.design", "_blank"),
-                  }
+                    buttonText: 'Learn more',
+                    onButtonClick: () => window.open('https://cloudscape.design', '_blank'),
+                  },
                 ]}
               />
             </SpaceBetween>
@@ -121,8 +200,8 @@ export default function Home() {
                 <div>
                   <Header variant="h2">Demo catalog</Header>
                   <Box variant="p">
-                    Browse {demos.length} examples of Cloudscape Design System patterns and components. 
-                    Each demo shows best practices for cloud application experiences.
+                    Browse {demos.length} examples of Cloudscape Design System patterns and components. Each demo shows
+                    best practices for cloud application experiences.
                   </Box>
                 </div>
 
@@ -151,57 +230,51 @@ export default function Home() {
             <Cards
               ariaLabels={{
                 itemSelectionLabel: (e, n) => `select ${n.title}`,
-                selectionGroupLabel: "Demo selection"
+                selectionGroupLabel: 'Demo selection',
               }}
               cardDefinition={{
-                header: item => (
-                  <Link href={item.route}>{item.title}</Link>
-                ),
+                header: item => <Link href={item.route}>{item.title}</Link>,
                 sections: [
                   {
-                    id: "description",
-                    content: item => item.description
+                    id: 'description',
+                    content: item => item.description,
                   },
                   {
-                    id: "type",
-                    header: "Category",
-                    content: item => (
-                      <Badge color="blue">{item.category}</Badge>
-                    )
+                    id: 'type',
+                    header: 'Category',
+                    content: item => <Badge color="blue">{item.category}</Badge>,
                   },
                   {
-                    id: "actions",
+                    id: 'actions',
                     content: item => (
                       <Button href={item.route} iconAlign="right" iconName="external" variant="primary">
                         Open demo
                       </Button>
-                    )
-                  }
-                ]
+                    ),
+                  },
+                ],
               }}
               cardsPerRow={[
                 { cards: 1, minWidth: 0 },
                 { cards: 2, minWidth: 500 },
                 { cards: 3, minWidth: 900 },
-                { cards: 4, minWidth: 1200 }
+                { cards: 4, minWidth: 1200 },
               ]}
               items={paginatedDemos}
               loadingText="Loading demos"
               selectedItems={selectedItems}
               selectionType="multi"
               trackBy="title"
-              visibleSections={["description", "type", "actions"]}
+              visibleSections={['description', 'type', 'actions']}
               empty={
                 <Box textAlign="center" color="inherit">
-                  <Box padding={{ bottom: "s" }} variant="p" color="inherit">
+                  <Box padding={{ bottom: 's' }} variant="p" color="inherit">
                     <Icon name="search" size="large" />
                   </Box>
-                  <Box variant="h3" padding={{ bottom: "xs" }}>
+                  <Box variant="h3" padding={{ bottom: 'xs' }}>
                     No demos match the filters
                   </Box>
-                  <Box variant="p">
-                    Try changing the filters or search term
-                  </Box>
+                  <Box variant="p">Try changing the filters or search term</Box>
                 </Box>
               }
               filter={
@@ -221,23 +294,17 @@ export default function Home() {
                   onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
                   pagesCount={Math.ceil(filteredDemos.length / itemsPerPage)}
                   ariaLabels={{
-                    nextPageLabel: "Next page",
-                    previousPageLabel: "Previous page",
-                    pageLabel: pageNumber => `Page ${pageNumber} of all pages`
+                    nextPageLabel: 'Next page',
+                    previousPageLabel: 'Previous page',
+                    pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
                   }}
                 />
               }
-              header={
-                <Header
-                  counter={`(${filteredDemos.length})`}
-                >
-                  Available demos
-                </Header>
-              }
+              header={<Header counter={`(${filteredDemos.length})`}>Available demos</Header>}
             />
           </SpaceBetween>
         </ContentLayout>
       }
     />
   );
-} 
+}

--- a/src/pages/random-user-dashboard/app.tsx
+++ b/src/pages/random-user-dashboard/app.tsx
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { Content } from './components/content';
+import { DashboardHeader, DashboardMainInfo } from './components/header';
+import { DashboardSideNavigation } from './components/side-navigation';
+import { useRandomUsers } from './hooks/use-random-users';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <DashboardMainInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const { users, loading, error, filter, setFilter, refreshUsers } = useRandomUsers();
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <DashboardHeader onRefresh={refreshUsers} loading={loading} filter={filter} onFilterChange={setFilter} />
+            <Content users={users} loading={loading} error={error} filter={filter} onFilterChange={setFilter} />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Random Users Dashboard', href: '#/' }]} />}
+        navigation={<DashboardSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/random-user-dashboard/components/content.tsx
+++ b/src/pages/random-user-dashboard/components/content.tsx
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Modal from '@cloudscape-design/components/modal';
+import Pagination from '@cloudscape-design/components/pagination';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+import TextFilter from '@cloudscape-design/components/text-filter';
+
+import { RandomUser } from '../types';
+import { DashboardFilters } from './header';
+import { UserDetails } from './user-details';
+
+interface ContentProps {
+  users: RandomUser[];
+  loading: boolean;
+  error: string | null;
+  filter: any;
+  onFilterChange: (filter: any) => void;
+}
+
+export function Content({ users, loading, error, filter, onFilterChange }: ContentProps) {
+  const [selectedUser, setSelectedUser] = useState<RandomUser | null>(null);
+  const [filterText, setFilterText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [selectedItems, setSelectedItems] = useState<RandomUser[]>([]);
+
+  const itemsPerPage = 10;
+
+  const filteredUsers = users.filter(
+    user =>
+      filterText === '' ||
+      user.name.first.toLowerCase().includes(filterText.toLowerCase()) ||
+      user.name.last.toLowerCase().includes(filterText.toLowerCase()) ||
+      user.email.toLowerCase().includes(filterText.toLowerCase()) ||
+      user.location.country.toLowerCase().includes(filterText.toLowerCase()),
+  );
+
+  // Calculate pagination
+  const pagesCount = Math.ceil(filteredUsers.length / itemsPerPage);
+  const startIndex = (currentPageIndex - 1) * itemsPerPage;
+  const displayedUsers = filteredUsers.slice(startIndex, startIndex + itemsPerPage);
+
+  return (
+    <SpaceBetween size="l">
+      {error && (
+        <Alert type="error" header="Error fetching user data">
+          {error}
+        </Alert>
+      )}
+
+      <DashboardFilters filter={filter} onFilterChange={onFilterChange} />
+
+      <Table
+        loading={loading}
+        loadingText="Loading users"
+        columnDefinitions={[
+          {
+            id: 'photo',
+            header: 'Photo',
+            cell: item => (
+              <img
+                src={item.picture.thumbnail}
+                alt={`${item.name.first} ${item.name.last}`}
+                style={{ width: 40, height: 40, borderRadius: '50%' }}
+              />
+            ),
+            sortingField: 'name.last',
+            width: 80,
+          },
+          {
+            id: 'name',
+            header: 'Name',
+            cell: item => `${item.name.first} ${item.name.last}`,
+            sortingField: 'name.last',
+          },
+          {
+            id: 'email',
+            header: 'Email',
+            cell: item => item.email,
+            sortingField: 'email',
+          },
+          {
+            id: 'gender',
+            header: 'Gender',
+            cell: item => item.gender,
+            sortingField: 'gender',
+          },
+          {
+            id: 'location',
+            header: 'Location',
+            cell: item => `${item.location.city}, ${item.location.country}`,
+            sortingField: 'location.country',
+          },
+          {
+            id: 'phone',
+            header: 'Phone',
+            cell: item => item.phone,
+            sortingField: 'phone',
+          },
+          {
+            id: 'age',
+            header: 'Age',
+            cell: item => item.dob.age,
+            sortingField: 'dob.age',
+          },
+          {
+            id: 'nationality',
+            header: 'Nationality',
+            cell: item => item.nat,
+            sortingField: 'nat',
+          },
+        ]}
+        items={displayedUsers}
+        selectionType="single"
+        selectedItems={selectedItems}
+        onSelectionChange={({ detail }) => {
+          setSelectedItems(detail.selectedItems);
+          if (detail.selectedItems.length > 0) {
+            setSelectedUser(detail.selectedItems[0]);
+          }
+        }}
+        empty={
+          <Box textAlign="center" padding="l">
+            <SpaceBetween size="xs" direction="vertical" alignItems="center">
+              <Box variant="h3">No users found</Box>
+              <Box variant="p">Try adjusting your filters or refresh to get new random users.</Box>
+              <Button onClick={() => onFilterChange({ resultsCount: 12 })}>Reset filters</Button>
+            </SpaceBetween>
+          </Box>
+        }
+        filter={
+          <TextFilter
+            filteringText={filterText}
+            filteringPlaceholder="Search users"
+            filteringAriaLabel="Filter users"
+            onChange={({ detail }) => setFilterText(detail.filteringText)}
+          />
+        }
+        pagination={
+          <Pagination
+            currentPageIndex={currentPageIndex}
+            pagesCount={pagesCount}
+            onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+          />
+        }
+        stickyHeader={true}
+        header={
+          <Box padding="s" textAlign="center">
+            <h2>User Directory</h2>
+          </Box>
+        }
+      />
+
+      {selectedUser && (
+        <Modal
+          visible={true}
+          header={`${selectedUser.name.first} ${selectedUser.name.last}'s Details`}
+          onDismiss={() => {
+            setSelectedUser(null);
+            setSelectedItems([]);
+          }}
+          size="large"
+        >
+          <UserDetails user={selectedUser} />
+        </Modal>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/src/pages/random-user-dashboard/components/header.tsx
+++ b/src/pages/random-user-dashboard/components/header.tsx
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Select, { SelectProps } from '@cloudscape-design/components/select';
+import FormField from '@cloudscape-design/components/form-field';
+
+import { RandomUserFilter } from '../types';
+
+interface DashboardHeaderProps {
+  onRefresh: () => void;
+  loading: boolean;
+  filter: RandomUserFilter;
+  onFilterChange: (filter: RandomUserFilter) => void;
+}
+
+export function DashboardHeader({ onRefresh, loading, filter, onFilterChange }: DashboardHeaderProps) {
+  return (
+    <Header
+      variant="h1"
+      actions={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button onClick={onRefresh} loading={loading}>
+            Refresh users
+          </Button>
+        </SpaceBetween>
+      }
+      counter={filter.resultsCount ? `(${filter.resultsCount})` : undefined}
+      description="View and manage random user profiles from randomuser.me API."
+    >
+      Random Users Dashboard
+    </Header>
+  );
+}
+
+export function DashboardFilters({
+  filter,
+  onFilterChange,
+}: {
+  filter: RandomUserFilter;
+  onFilterChange: (filter: RandomUserFilter) => void;
+}) {
+  const genderOptions: SelectProps.Option[] = [
+    { value: '', label: 'All genders' },
+    { value: 'male', label: 'Male' },
+    { value: 'female', label: 'Female' },
+  ];
+
+  const nationalityOptions: SelectProps.Option[] = [
+    { value: '', label: 'All nationalities' },
+    { value: 'us', label: 'United States' },
+    { value: 'gb', label: 'United Kingdom' },
+    { value: 'fr', label: 'France' },
+    { value: 'de', label: 'Germany' },
+    { value: 'ca', label: 'Canada' },
+    { value: 'au', label: 'Australia' },
+    { value: 'br', label: 'Brazil' },
+    { value: 'ch', label: 'Switzerland' },
+    { value: 'nl', label: 'Netherlands' },
+    { value: 'no', label: 'Norway' },
+  ];
+
+  const resultCountOptions: SelectProps.Option[] = [
+    { value: '10', label: '10 users' },
+    { value: '25', label: '25 users' },
+    { value: '50', label: '50 users' },
+    { value: '100', label: '100 users' },
+  ];
+
+  return (
+    <Box padding="s">
+      <SpaceBetween direction="horizontal" size="l">
+        <FormField label="Gender">
+          <Select
+            selectedOption={genderOptions.find(option => option.value === filter.gender) || genderOptions[0]}
+            onChange={({ detail }) => onFilterChange({ ...filter, gender: detail.selectedOption.value || undefined })}
+            options={genderOptions}
+          />
+        </FormField>
+
+        <FormField label="Nationality">
+          <Select
+            selectedOption={
+              nationalityOptions.find(option => option.value === filter.nationality) || nationalityOptions[0]
+            }
+            onChange={({ detail }) =>
+              onFilterChange({ ...filter, nationality: detail.selectedOption.value || undefined })
+            }
+            options={nationalityOptions}
+          />
+        </FormField>
+
+        <FormField label="Results count">
+          <Select
+            selectedOption={
+              resultCountOptions.find(option => option.value === String(filter.resultsCount)) || resultCountOptions[1]
+            }
+            onChange={({ detail }) =>
+              onFilterChange({
+                ...filter,
+                resultsCount: detail.selectedOption.value ? parseInt(detail.selectedOption.value, 10) : 25,
+              })
+            }
+            options={resultCountOptions}
+          />
+        </FormField>
+      </SpaceBetween>
+    </Box>
+  );
+}
+
+export function DashboardMainInfo() {
+  return (
+    <div>
+      <Box variant="h2">Random Users Dashboard</Box>
+      <p>
+        This dashboard demonstrates integration with the RandomUser.me API to display user profiles in a table view.
+      </p>
+      <h3>Features:</h3>
+      <ul>
+        <li>Browse users in a sortable, filterable table</li>
+        <li>Filter users by gender and nationality</li>
+        <li>Refresh data to get new random users</li>
+        <li>Select a user to view detailed information</li>
+        <li>Search for specific users with the text filter</li>
+      </ul>
+      <h3>API Information:</h3>
+      <p>
+        This demo uses the RandomUser.me API, a free open-source API for generating random user data. No API key is
+        required, but usage limitations apply.
+      </p>
+      <p>
+        <a href="https://randomuser.me/" target="_blank" rel="noopener noreferrer">
+          Visit RandomUser.me for more information
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/pages/random-user-dashboard/components/side-navigation.tsx
+++ b/src/pages/random-user-dashboard/components/side-navigation.tsx
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation from '@cloudscape-design/components/side-navigation';
+
+export function DashboardSideNavigation() {
+  return (
+    <SideNavigation
+      activeHref="#/random-users"
+      header={{ text: 'Random User Demo', href: '#/' }}
+      items={[
+        { type: 'link', text: 'Dashboard', href: '#/random-users' },
+        { type: 'divider' },
+        {
+          type: 'link',
+          text: 'Documentation',
+          href: 'https://randomuser.me/documentation',
+          external: true,
+        },
+        {
+          type: 'link',
+          text: 'API',
+          href: 'https://randomuser.me/api',
+          external: true,
+        },
+      ]}
+    />
+  );
+}

--- a/src/pages/random-user-dashboard/components/user-card.tsx
+++ b/src/pages/random-user-dashboard/components/user-card.tsx
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Link from '@cloudscape-design/components/link';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { RandomUser } from '../types';
+
+interface UserCardProps {
+  user: RandomUser;
+  onShowDetails: (user: RandomUser) => void;
+}
+
+export function UserCard({ user, onShowDetails }: UserCardProps) {
+  const fullName = `${user.name.title} ${user.name.first} ${user.name.last}`;
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h3"
+          actions={
+            <Button onClick={() => onShowDetails(user)} variant="normal">
+              View details
+            </Button>
+          }
+        >
+          {fullName}
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <img
+            src={user.picture.medium}
+            alt={fullName}
+            style={{
+              width: 80,
+              height: 80,
+              borderRadius: '50%',
+              marginRight: 16,
+            }}
+          />
+          <div>
+            <Box variant="h3" padding="n">
+              {fullName}
+            </Box>
+            <Box variant="p" padding="n">
+              <Link external href={`mailto:${user.email}`}>
+                {user.email}
+              </Link>
+            </Box>
+            <Box variant="p" padding="n">
+              <StatusIndicator type="success">Active</StatusIndicator>
+            </Box>
+          </div>
+        </div>
+
+        <SpaceBetween size="xs">
+          <Box variant="p">
+            <strong>Location:</strong> {user.location.city}, {user.location.country}
+          </Box>
+          <Box variant="p">
+            <strong>Phone:</strong> {user.phone}
+          </Box>
+          <Box variant="p">
+            <strong>Age:</strong> {user.dob.age}
+          </Box>
+          <Box variant="p">
+            <strong>Nationality:</strong> {user.nat}
+          </Box>
+        </SpaceBetween>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/random-user-dashboard/components/user-details.tsx
+++ b/src/pages/random-user-dashboard/components/user-details.tsx
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Link from '@cloudscape-design/components/link';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { RandomUser } from '../types';
+
+interface UserDetailsProps {
+  user: RandomUser;
+}
+
+export function UserDetails({ user }: UserDetailsProps) {
+  const fullName = `${user.name.title} ${user.name.first} ${user.name.last}`;
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <SpaceBetween size="l">
+      <Container header={<Header variant="h2">User information</Header>}>
+        <SpaceBetween size="l">
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <img
+              src={user.picture.large}
+              alt={fullName}
+              style={{
+                width: 120,
+                height: 120,
+                borderRadius: '50%',
+                marginRight: 24,
+              }}
+            />
+            <div>
+              <Box variant="h1" padding="n">
+                {fullName}
+              </Box>
+              <Box variant="p" padding="n">
+                <Link external href={`mailto:${user.email}`}>
+                  {user.email}
+                </Link>
+              </Box>
+              <Box variant="p" padding="n">
+                Username: {user.login.username}
+              </Box>
+            </div>
+          </div>
+
+          <ColumnLayout columns={2} variant="text-grid">
+            <SpaceBetween size="l">
+              <div>
+                <Box variant="h3">Contact information</Box>
+                <Box variant="p">
+                  <strong>Email:</strong> {user.email}
+                </Box>
+                <Box variant="p">
+                  <strong>Phone:</strong> {user.phone}
+                </Box>
+                <Box variant="p">
+                  <strong>Cell:</strong> {user.cell}
+                </Box>
+              </div>
+
+              <div>
+                <Box variant="h3">Personal information</Box>
+                <Box variant="p">
+                  <strong>Gender:</strong> {user.gender}
+                </Box>
+                <Box variant="p">
+                  <strong>Date of birth:</strong> {formatDate(user.dob.date)} ({user.dob.age} years)
+                </Box>
+                <Box variant="p">
+                  <strong>Nationality:</strong> {user.nat}
+                </Box>
+              </div>
+            </SpaceBetween>
+
+            <SpaceBetween size="l">
+              <div>
+                <Box variant="h3">Address</Box>
+                <Box variant="p">
+                  <strong>Street:</strong> {user.location.street.number} {user.location.street.name}
+                </Box>
+                <Box variant="p">
+                  <strong>City:</strong> {user.location.city}
+                </Box>
+                <Box variant="p">
+                  <strong>State:</strong> {user.location.state}
+                </Box>
+                <Box variant="p">
+                  <strong>Country:</strong> {user.location.country}
+                </Box>
+                <Box variant="p">
+                  <strong>Postcode:</strong> {user.location.postcode}
+                </Box>
+              </div>
+
+              <div>
+                <Box variant="h3">Account information</Box>
+                <Box variant="p">
+                  <strong>UUID:</strong> {user.login.uuid}
+                </Box>
+                <Box variant="p">
+                  <strong>Username:</strong> {user.login.username}
+                </Box>
+              </div>
+            </SpaceBetween>
+          </ColumnLayout>
+        </SpaceBetween>
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/random-user-dashboard/hooks/use-random-users.ts
+++ b/src/pages/random-user-dashboard/hooks/use-random-users.ts
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { useState, useEffect, useCallback } from 'react';
+import { RandomUser, RandomUserFilter, RandomUserResponse } from '../types';
+
+export function useRandomUsers() {
+  const [users, setUsers] = useState<RandomUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<RandomUserFilter>({
+    resultsCount: 25, // Increased for table view
+  });
+
+  const fetchUsers = useCallback(
+    async (forceRefresh = false) => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const params = new URLSearchParams();
+        params.append('results', `${filter.resultsCount || 25}`);
+
+        if (filter.gender) {
+          params.append('gender', filter.gender);
+        }
+
+        if (filter.nationality) {
+          params.append('nat', filter.nationality);
+        }
+
+        // Add a seed for consistent results unless forcing a refresh
+        if (!forceRefresh) {
+          params.append('seed', 'cloudscape-demo');
+        }
+
+        const response = await fetch(`https://randomuser.me/api/?${params.toString()}`);
+
+        if (!response.ok) {
+          throw new Error(`API response error: ${response.status}`);
+        }
+
+        const data: RandomUserResponse = await response.json();
+        setUsers(data.results);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch user data');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [filter],
+  );
+
+  // Fetch users when filter changes
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  return {
+    users,
+    loading,
+    error,
+    filter,
+    setFilter,
+    refreshUsers: () => fetchUsers(true),
+  };
+}

--- a/src/pages/random-user-dashboard/index.tsx
+++ b/src/pages/random-user-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function RandomUserDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/random-user-dashboard/types.ts
+++ b/src/pages/random-user-dashboard/types.ts
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface UserName {
+  title: string;
+  first: string;
+  last: string;
+}
+
+export interface UserLocation {
+  street: {
+    number: number;
+    name: string;
+  };
+  city: string;
+  state: string;
+  country: string;
+  postcode: string;
+}
+
+export interface UserPicture {
+  large: string;
+  medium: string;
+  thumbnail: string;
+}
+
+export interface UserLoginInfo {
+  uuid: string;
+  username: string;
+  email: string;
+}
+
+export interface RandomUser {
+  gender: string;
+  name: UserName;
+  location: UserLocation;
+  email: string;
+  login: UserLoginInfo;
+  dob: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell: string;
+  picture: UserPicture;
+  nat: string;
+}
+
+export interface RandomUserResponse {
+  results: RandomUser[];
+  info: {
+    seed: string;
+    results: number;
+    page: number;
+    version: string;
+  };
+}
+
+export interface RandomUserFilter {
+  gender?: string;
+  nationality?: string;
+  resultsCount?: number;
+}


### PR DESCRIPTION
Add a new Bitcoin price dashboard demo that displays real-time cryptocurrency prices from the CoinDesk API. The dashboard includes:

- Real-time price cards for USD, GBP, and EUR
- Interactive price chart with currency selection
- Historical price table with filtering and pagination
- Auto-refresh functionality
- Responsive layout using Cloudscape components

The demo follows the same patterns and structure as other dashboard examples in the project.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=echo-den&projectId=98bf2453a9fe441eb6778cbc07f519aa)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->