### PR TITLE
Add US Population Dashboard demo

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/us-population-dashboard',
+    title: 'US Population Dashboard',
+    description: 'Dashboard for US population data.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/us-population-dashboard/app.tsx
+++ b/src/pages/us-population-dashboard/app.tsx
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { DashboardSideNavigation } from '../dashboard/components/side-navigation';
+import { Content } from './content';
+import { USPopulationDashboardHeader, USPopulationDashboardMainInfo } from './components/header';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <USPopulationDashboardMainInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <USPopulationDashboardHeader
+              actions={
+                <Button
+                  variant="primary"
+                  href="https://datausa.io/about/api/"
+                  external
+                  iconAlign="right"
+                  iconName="external"
+                >
+                  View API Documentation
+                </Button>
+              }
+            />
+            <Content />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'US Population Dashboard', href: '#/' }]} />}
+        navigation={<DashboardSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/us-population-dashboard/components/header.tsx
+++ b/src/pages/us-population-dashboard/components/header.tsx
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Header from '@cloudscape-design/components/header';
+import HelpPanel from '@cloudscape-design/components/help-panel';
+
+import { ExternalLinkGroup, InfoLink, useHelpPanel } from '../../commons';
+
+export function USPopulationDashboardMainInfo() {
+  return (
+    <HelpPanel
+      header={<h2>US Population Dashboard</h2>}
+      footer={
+        <ExternalLinkGroup
+          items={[
+            { href: 'https://datausa.io/about/api/', text: 'DataUSA API Documentation' },
+            { href: 'https://github.com/DataUSA/datausa-api/wiki', text: 'DataUSA API Wiki' },
+            { href: 'https://www.census.gov/', text: 'US Census Bureau' },
+          ]}
+        />
+      }
+    >
+      <p>
+        This dashboard displays population data for the United States, sourced from the DataUSA API. The data includes
+        national population trends over time and population statistics by state.
+      </p>
+      <p>
+        <strong>Features:</strong>
+      </p>
+      <ul>
+        <li>View total US population and growth trends</li>
+        <li>Compare population data across different states</li>
+        <li>Analyze population changes over time</li>
+        <li>Filter data by year and state</li>
+      </ul>
+      <p>The data is sourced from the US Census Bureau and made available through the DataUSA API.</p>
+    </HelpPanel>
+  );
+}
+
+export function USPopulationDashboardHeader({ actions }: { actions?: React.ReactNode }) {
+  const loadHelpPanelContent = useHelpPanel();
+  return (
+    <Header
+      variant="h1"
+      info={<InfoLink onFollow={() => loadHelpPanelContent(<USPopulationDashboardMainInfo />)} />}
+      actions={actions}
+    >
+      US Population Dashboard
+    </Header>
+  );
+}

--- a/src/pages/us-population-dashboard/components/metrics-cards.tsx
+++ b/src/pages/us-population-dashboard/components/metrics-cards.tsx
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Grid from '@cloudscape-design/components/grid';
+import Header from '@cloudscape-design/components/header';
+import ProgressBar from '@cloudscape-design/components/progress-bar';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { PopulationMetricData } from '../interfaces';
+import dataProvider from '../data-provider';
+
+interface MetricsCardsProps {
+  title?: string;
+}
+
+export function MetricsCards({ title = 'Population Metrics' }: MetricsCardsProps) {
+  const [metrics, setMetrics] = useState<PopulationMetricData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const metricsData = await dataProvider.getKeyMetrics();
+        setMetrics(metricsData);
+        setLoading(false);
+      } catch (err) {
+        setError('Error loading population metrics');
+        setLoading(false);
+        console.error(err);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <SpaceBetween size="m">
+          <ProgressBar
+            label="Loading metrics"
+            description="Please wait while we load the population metrics"
+            value={-1}
+          />
+        </SpaceBetween>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <Box color="text-status-error">{error}</Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container header={<Header variant="h2">{title}</Header>}>
+      <Grid
+        gridDefinition={[
+          { colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 4 } },
+          { colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 4 } },
+          { colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 4 } },
+        ]}
+      >
+        {metrics.map((metric, index) => (
+          <MetricCard key={index} metric={metric} />
+        ))}
+      </Grid>
+    </Container>
+  );
+}
+
+interface MetricCardProps {
+  metric: PopulationMetricData;
+}
+
+function MetricCard({ metric }: MetricCardProps) {
+  return (
+    <div className="metric-card">
+      <Box variant="h3">{metric.title}</Box>
+      <Box variant="h1" padding={{ top: 'xs', bottom: 'xs' }}>
+        {metric.value}
+      </Box>
+
+      {metric.previousValue && (
+        <Box variant="p" color="text-body-secondary">
+          Previous: {metric.previousValue}
+        </Box>
+      )}
+
+      {metric.change !== undefined && metric.changeType && (
+        <Box padding={{ top: 'xs' }}>
+          <StatusIndicator
+            type={metric.changeType === 'positive' ? 'success' : metric.changeType === 'negative' ? 'error' : 'info'}
+          >
+            {metric.change > 0 ? '+' : ''}
+            {metric.change.toFixed(2)}% from previous
+          </StatusIndicator>
+        </Box>
+      )}
+    </div>
+  );
+}

--- a/src/pages/us-population-dashboard/components/population-chart.tsx
+++ b/src/pages/us-population-dashboard/components/population-chart.tsx
@@ -1,0 +1,109 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import ProgressBar from '@cloudscape-design/components/progress-bar';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { PopulationTrendData } from '../interfaces';
+import dataProvider from '../data-provider';
+
+interface PopulationChartProps {
+  title?: string;
+}
+
+export function PopulationChart({ title = 'Population Trend Over Time' }: PopulationChartProps) {
+  const [data, setData] = useState<PopulationTrendData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const populationData = await dataProvider.getPopulationTrend();
+        setData(populationData);
+        setLoading(false);
+      } catch (err) {
+        setError('Error loading population trend data');
+        setLoading(false);
+        console.error(err);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <SpaceBetween size="m">
+          <ProgressBar
+            label="Loading population data"
+            description="Please wait while we load the population trend data"
+            value={-1}
+          />
+        </SpaceBetween>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <Box color="text-status-error">{error}</Box>
+      </Container>
+    );
+  }
+
+  // Format data for the bar chart
+  const chartData = data.map(item => ({
+    x: item.year.toString(),
+    y: item.population,
+  }));
+
+  // Sort data by year in ascending order
+  chartData.sort((a, b) => parseInt(a.x) - parseInt(b.x));
+
+  return (
+    <Container header={<Header variant="h2">{title}</Header>}>
+      <BarChart
+        series={[
+          {
+            title: 'Population',
+            type: 'bar',
+            data: chartData,
+          },
+        ]}
+        xTitle="Year"
+        yTitle="Population"
+        xScaleType="categorical"
+        hideFilter
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No data available</b>
+            <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+              There is no population data available for the selected filters.
+            </Box>
+          </Box>
+        }
+        height={300}
+        ariaLabel="Population trend over time"
+        ariaDescription="Bar chart showing US population trend over multiple years."
+        i18nStrings={{
+          filterLabel: 'Filter displayed data',
+          filterPlaceholder: 'Filter data',
+          filterSelectedAriaLabel: 'selected',
+          legendAriaLabel: 'Legend',
+          chartAriaRoleDescription: 'bar chart',
+          xAxisAriaRoleDescription: 'year',
+          yAxisAriaRoleDescription: 'population',
+        }}
+      />
+    </Container>
+  );
+}

--- a/src/pages/us-population-dashboard/components/population-table.tsx
+++ b/src/pages/us-population-dashboard/components/population-table.tsx
@@ -1,0 +1,150 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Pagination from '@cloudscape-design/components/pagination';
+import ProgressBar from '@cloudscape-design/components/progress-bar';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+import TextFilter from '@cloudscape-design/components/text-filter';
+
+import { PopulationByStateData, StatePopulationData } from '../interfaces';
+import dataProvider from '../data-provider';
+
+interface PopulationTableProps {
+  title?: string;
+  selectedYear?: number;
+}
+
+export function PopulationTable({ title = 'Population by State', selectedYear }: PopulationTableProps) {
+  const [data, setData] = useState<PopulationByStateData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filterText, setFilterText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [displayYear, setDisplayYear] = useState<number | null>(null);
+
+  const itemsPerPage = 10;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const stateData = await dataProvider.getPopulationByState(selectedYear);
+        setData(stateData);
+        setDisplayYear(stateData[0]?.year || null);
+        setLoading(false);
+      } catch (err) {
+        setError('Error loading state population data');
+        setLoading(false);
+        console.error(err);
+      }
+    };
+
+    fetchData();
+  }, [selectedYear]);
+
+  // Filter data based on search text
+  const filteredData = data.filter(item => item.state.toLowerCase().includes(filterText.toLowerCase()));
+
+  // Paginate data
+  const paginatedData = filteredData.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+
+  // Format population number with commas
+  const formatNumber = (num: number) => {
+    return new Intl.NumberFormat('en-US').format(num);
+  };
+
+  if (loading) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <SpaceBetween size="m">
+          <ProgressBar
+            label="Loading population data"
+            description="Please wait while we load the state population data"
+            value={-1}
+          />
+        </SpaceBetween>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <Box color="text-status-error">{error}</Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" counter={data.length > 0 ? `(${data.length})` : undefined}>
+          {displayYear ? `${title} (${displayYear})` : title}
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        <TextFilter
+          filteringText={filterText}
+          filteringPlaceholder="Find state"
+          filteringAriaLabel="Filter states"
+          onChange={({ detail }) => {
+            setFilterText(detail.filteringText);
+            setCurrentPage(1);
+          }}
+          countText={`${filteredData.length} matches`}
+          disabled={data.length === 0}
+        />
+        <Table
+          columnDefinitions={[
+            {
+              id: 'state',
+              header: 'State',
+              cell: item => item.state,
+              sortingField: 'state',
+            },
+            {
+              id: 'population',
+              header: 'Population',
+              cell: item => formatNumber(item.population),
+              sortingField: 'population',
+            },
+          ]}
+          items={paginatedData}
+          trackBy="state"
+          loading={loading}
+          loadingText="Loading state population data"
+          sortingDescending
+          sortingColumn="population"
+          empty={
+            <Box textAlign="center" color="inherit">
+              <b>No data available</b>
+              <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                There is no population data available for the selected filters.
+              </Box>
+            </Box>
+          }
+          wrapLines
+          header={<div>State population data</div>}
+          pagination={
+            <Pagination
+              currentPageIndex={currentPage}
+              onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+              pagesCount={Math.max(1, Math.ceil(filteredData.length / itemsPerPage))}
+              ariaLabels={{
+                nextPageLabel: 'Next page',
+                previousPageLabel: 'Previous page',
+                pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
+              }}
+            />
+          }
+        />
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/us-population-dashboard/components/population-table.tsx
+++ b/src/pages/us-population-dashboard/components/population-table.tsx
@@ -11,7 +11,7 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import Table from '@cloudscape-design/components/table';
 import TextFilter from '@cloudscape-design/components/text-filter';
 
-import { PopulationByStateData, StatePopulationData } from '../interfaces';
+import { PopulationByStateData } from '../interfaces';
 import dataProvider from '../data-provider';
 
 interface PopulationTableProps {
@@ -29,6 +29,7 @@ export function PopulationTable({ title = 'Population by State', selectedYear }:
 
   const itemsPerPage = 10;
 
+  // This useEffect will run whenever selectedYear changes
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -45,7 +46,7 @@ export function PopulationTable({ title = 'Population by State', selectedYear }:
     };
 
     fetchData();
-  }, [selectedYear]);
+  }, [selectedYear]); // Dependency on selectedYear ensures data refreshes when year changes
 
   // Filter data based on search text
   const filteredData = data.filter(item => item.state.toLowerCase().includes(filterText.toLowerCase()));

--- a/src/pages/us-population-dashboard/components/state-pie-chart.tsx
+++ b/src/pages/us-population-dashboard/components/state-pie-chart.tsx
@@ -23,6 +23,7 @@ export function StatePieChart({ title = 'Population Distribution', selectedYear,
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // This useEffect will run whenever selectedYear or selectedStates changes
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -45,7 +46,7 @@ export function StatePieChart({ title = 'Population Distribution', selectedYear,
     };
 
     fetchData();
-  }, [selectedYear, selectedStates]);
+  }, [selectedYear, selectedStates]); // Add both dependencies to trigger refresh when either changes
 
   if (loading) {
     return (

--- a/src/pages/us-population-dashboard/components/state-pie-chart.tsx
+++ b/src/pages/us-population-dashboard/components/state-pie-chart.tsx
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import PieChart from '@cloudscape-design/components/pie-chart';
+import ProgressBar from '@cloudscape-design/components/progress-bar';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { PopulationByStateData } from '../interfaces';
+import dataProvider from '../data-provider';
+
+interface StatePieChartProps {
+  title?: string;
+  selectedYear?: number;
+  selectedStates: string[];
+}
+
+export function StatePieChart({ title = 'Population Distribution', selectedYear, selectedStates }: StatePieChartProps) {
+  const [data, setData] = useState<PopulationByStateData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const stateData = await dataProvider.getPopulationByState(selectedYear);
+
+        // If specific states are selected, filter the data
+        const filteredData =
+          selectedStates.length > 0
+            ? stateData.filter(item => selectedStates.includes(item.state))
+            : stateData.slice(0, 10); // Show top 10 if no states selected
+
+        setData(filteredData);
+        setLoading(false);
+      } catch (err) {
+        setError('Error loading state population data');
+        setLoading(false);
+        console.error(err);
+      }
+    };
+
+    fetchData();
+  }, [selectedYear, selectedStates]);
+
+  if (loading) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <SpaceBetween size="m">
+          <ProgressBar
+            label="Loading population data"
+            description="Please wait while we load the state population data"
+            value={-1}
+          />
+        </SpaceBetween>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container header={<Header variant="h2">{title}</Header>}>
+        <Box color="text-status-error">{error}</Box>
+      </Container>
+    );
+  }
+
+  // Format data for the pie chart
+  const chartData = data.map(item => ({
+    title: item.state,
+    value: item.population,
+  }));
+
+  // Sort data by population in descending order
+  chartData.sort((a, b) => b.value - a.value);
+
+  const yearLabel = selectedYear ? ` (${selectedYear})` : '';
+  const displayTitle =
+    selectedStates.length > 0 ? `${title} - Selected States${yearLabel}` : `${title} - Top 10 States${yearLabel}`;
+
+  return (
+    <Container header={<Header variant="h2">{displayTitle}</Header>}>
+      <PieChart
+        data={chartData}
+        detailPopoverContent={(datum, sum) => [
+          { key: 'State', value: datum.title },
+          { key: 'Population', value: datum.value.toLocaleString() },
+          {
+            key: 'Percentage',
+            value: `${((datum.value / sum) * 100).toFixed(1)}%`,
+          },
+        ]}
+        i18nStrings={{
+          detailsValue: 'Value',
+          detailsPercentage: 'Percentage',
+          filterLabel: 'Filter displayed data',
+          filterPlaceholder: 'Filter data',
+          filterSelectedAriaLabel: 'selected',
+          detailPopoverDismissAriaLabel: 'Dismiss',
+          legendAriaLabel: 'Legend',
+          chartAriaRoleDescription: 'pie chart',
+          segmentAriaRoleDescription: 'segment',
+        }}
+        ariaDescription="Pie chart showing population distribution across states."
+        ariaLabel="State Population Distribution Pie Chart"
+        hideFilter
+        size="large"
+        variant="donut"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No data available</b>
+            <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+              There is no population data available for the selected filters.
+            </Box>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/us-population-dashboard/components/state-selector.tsx
+++ b/src/pages/us-population-dashboard/components/state-selector.tsx
@@ -50,7 +50,7 @@ export function StateSelector({ onYearChange, onStatesChange, selectedStates, se
     };
 
     fetchData();
-  }, [onYearChange, selectedYear]);
+  }, []); // Run only on mount
 
   if (loading) {
     return (
@@ -82,6 +82,7 @@ export function StateSelector({ onYearChange, onStatesChange, selectedStates, se
             selectedOption={selectedYear ? { label: selectedYear.toString(), value: selectedYear.toString() } : null}
             onChange={({ detail }) => {
               if (detail.selectedOption) {
+                // Immediately call the parent handler to update state
                 onYearChange(parseInt(detail.selectedOption.value as string));
               }
             }}
@@ -95,6 +96,7 @@ export function StateSelector({ onYearChange, onStatesChange, selectedStates, se
           <Multiselect
             selectedOptions={selectedStates.map(state => ({ label: state, value: state }))}
             onChange={({ detail }) => {
+              // Immediately call the parent handler to update state
               onStatesChange(detail.selectedOptions.map(option => option.value as string));
             }}
             options={states.map(state => ({ label: state, value: state }))}

--- a/src/pages/us-population-dashboard/components/state-selector.tsx
+++ b/src/pages/us-population-dashboard/components/state-selector.tsx
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import FormField from '@cloudscape-design/components/form-field';
+import Header from '@cloudscape-design/components/header';
+import Multiselect from '@cloudscape-design/components/multiselect';
+import ProgressBar from '@cloudscape-design/components/progress-bar';
+import Select from '@cloudscape-design/components/select';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import dataProvider from '../data-provider';
+
+interface StateSelectorProps {
+  onYearChange: (year: number) => void;
+  onStatesChange: (states: string[]) => void;
+  selectedStates: string[];
+  selectedYear: number | null;
+}
+
+export function StateSelector({ onYearChange, onStatesChange, selectedStates, selectedYear }: StateSelectorProps) {
+  const [years, setYears] = useState<number[]>([]);
+  const [states, setStates] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const availableYears = await dataProvider.getAvailableYears();
+        const availableStates = await dataProvider.getAvailableStates();
+
+        setYears(availableYears);
+        setStates(availableStates);
+
+        // Set initial year if none selected
+        if (!selectedYear && availableYears.length > 0) {
+          onYearChange(availableYears[0]);
+        }
+
+        setLoading(false);
+      } catch (err) {
+        setError('Error loading filter options');
+        setLoading(false);
+        console.error(err);
+      }
+    };
+
+    fetchData();
+  }, [onYearChange, selectedYear]);
+
+  if (loading) {
+    return (
+      <Container header={<Header variant="h2">Filters</Header>}>
+        <SpaceBetween size="m">
+          <ProgressBar
+            label="Loading filter options"
+            description="Please wait while we load the available filter options"
+            value={-1}
+          />
+        </SpaceBetween>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container header={<Header variant="h2">Filters</Header>}>
+        <Box color="text-status-error">{error}</Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container header={<Header variant="h2">Data Filters</Header>}>
+      <SpaceBetween size="m">
+        <FormField label="Year" description="Select a year to view population data">
+          <Select
+            selectedOption={selectedYear ? { label: selectedYear.toString(), value: selectedYear.toString() } : null}
+            onChange={({ detail }) => {
+              if (detail.selectedOption) {
+                onYearChange(parseInt(detail.selectedOption.value as string));
+              }
+            }}
+            options={years.map(year => ({ label: year.toString(), value: year.toString() }))}
+            placeholder="Select a year"
+            empty="No years available"
+          />
+        </FormField>
+
+        <FormField label="States" description="Select states to compare (for comparison charts)">
+          <Multiselect
+            selectedOptions={selectedStates.map(state => ({ label: state, value: state }))}
+            onChange={({ detail }) => {
+              onStatesChange(detail.selectedOptions.map(option => option.value as string));
+            }}
+            options={states.map(state => ({ label: state, value: state }))}
+            placeholder="Select states"
+            deselectAriaLabel={option => `Remove ${option.label}`}
+            filteringType="auto"
+            empty="No states available"
+          />
+        </FormField>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/us-population-dashboard/content.tsx
+++ b/src/pages/us-population-dashboard/content.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import Alert from '@cloudscape-design/components/alert';
 import Grid from '@cloudscape-design/components/grid';
@@ -15,6 +15,17 @@ import { StatePieChart } from './components/state-pie-chart';
 export function Content() {
   const [selectedYear, setSelectedYear] = useState<number | null>(null);
   const [selectedStates, setSelectedStates] = useState<string[]>([]);
+
+  // Use useCallback to prevent unnecessary re-renders
+  const handleYearChange = useCallback((year: number) => {
+    console.log('Year changed to:', year);
+    setSelectedYear(year);
+  }, []);
+
+  const handleStatesChange = useCallback((states: string[]) => {
+    console.log('States changed to:', states);
+    setSelectedStates(states);
+  }, []);
 
   return (
     <SpaceBetween size="l">
@@ -33,8 +44,8 @@ export function Content() {
       >
         {/* Filters Panel */}
         <StateSelector
-          onYearChange={setSelectedYear}
-          onStatesChange={setSelectedStates}
+          onYearChange={handleYearChange}
+          onStatesChange={handleStatesChange}
           selectedStates={selectedStates}
           selectedYear={selectedYear}
         />

--- a/src/pages/us-population-dashboard/content.tsx
+++ b/src/pages/us-population-dashboard/content.tsx
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Alert from '@cloudscape-design/components/alert';
+import Grid from '@cloudscape-design/components/grid';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { MetricsCards } from './components/metrics-cards';
+import { PopulationChart } from './components/population-chart';
+import { PopulationTable } from './components/population-table';
+import { StateSelector } from './components/state-selector';
+import { StatePieChart } from './components/state-pie-chart';
+
+export function Content() {
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+  const [selectedStates, setSelectedStates] = useState<string[]>([]);
+
+  return (
+    <SpaceBetween size="l">
+      <Alert type="info" header="Data Source Information">
+        This dashboard displays US population data from DataUSA.io. The data is sourced from the US Census Bureau.
+      </Alert>
+
+      <Grid
+        gridDefinition={[
+          { colspan: { default: 12, l: 3, m: 4, s: 12 } },
+          { colspan: { default: 12, l: 9, m: 8, s: 12 } },
+          { colspan: { default: 12, l: 12, m: 12, s: 12 } },
+          { colspan: { default: 12, l: 8, m: 8, s: 12 } },
+          { colspan: { default: 12, l: 4, m: 4, s: 12 } },
+        ]}
+      >
+        {/* Filters Panel */}
+        <StateSelector
+          onYearChange={setSelectedYear}
+          onStatesChange={setSelectedStates}
+          selectedStates={selectedStates}
+          selectedYear={selectedYear}
+        />
+
+        {/* Key Metrics */}
+        <MetricsCards title="Key Population Metrics" />
+
+        {/* Population Trend Chart */}
+        <PopulationChart title="US Population Trend Over Time" />
+
+        {/* Population By State Table */}
+        <PopulationTable title="Population by State" selectedYear={selectedYear || undefined} />
+
+        {/* State Population Distribution Pie Chart */}
+        <StatePieChart
+          title="Population Distribution"
+          selectedYear={selectedYear || undefined}
+          selectedStates={selectedStates}
+        />
+      </Grid>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/us-population-dashboard/data-provider.ts
+++ b/src/pages/us-population-dashboard/data-provider.ts
@@ -1,0 +1,157 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import {
+  PopulationByStateData,
+  PopulationData,
+  PopulationMetricData,
+  PopulationTrendData,
+  StatePopulationData,
+} from './interfaces';
+
+// Base API URL for DataUSA
+const BASE_URL = 'https://datausa.io/api/data';
+
+class USPopulationDataProvider {
+  // Fetch national population data
+  async getNationalPopulationData(): Promise<PopulationData[]> {
+    const params = new URLSearchParams({
+      drilldowns: 'Nation',
+      measures: 'Population',
+    });
+
+    const response = await fetch(`${BASE_URL}?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(`Response error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data.data || [];
+  }
+
+  // Fetch state population data
+  async getStatePopulationData(): Promise<StatePopulationData[]> {
+    const params = new URLSearchParams({
+      drilldowns: 'State',
+      measures: 'Population',
+    });
+
+    const response = await fetch(`${BASE_URL}?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(`Response error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data.data || [];
+  }
+
+  // Get population trend data (formatted for charts)
+  async getPopulationTrend(): Promise<PopulationTrendData[]> {
+    const nationalData = await this.getNationalPopulationData();
+
+    // Sort by year (ascending)
+    const sortedData = [...nationalData].sort((a, b) => parseInt(a.Year) - parseInt(b.Year));
+
+    return sortedData.map(item => ({
+      year: parseInt(item.Year),
+      population: item.Population,
+    }));
+  }
+
+  // Get population data by state (for the most recent available year)
+  async getPopulationByState(year?: number): Promise<PopulationByStateData[]> {
+    const stateData = await this.getStatePopulationData();
+
+    // Filter by specified year or get the most recent year
+    let targetYear = year;
+    if (!targetYear) {
+      const years = stateData.map(item => parseInt(item.Year));
+      targetYear = Math.max(...years);
+    }
+
+    const filteredData = stateData.filter(item => parseInt(item.Year) === targetYear);
+
+    return filteredData.map(item => ({
+      state: item.State,
+      population: item.Population,
+      year: parseInt(item.Year),
+    }));
+  }
+
+  // Calculate population growth rate
+  async getPopulationGrowthRate(): Promise<number> {
+    const trendData = await this.getPopulationTrend();
+
+    if (trendData.length < 2) {
+      return 0;
+    }
+
+    // Sort by year in ascending order
+    const sortedData = [...trendData].sort((a, b) => a.year - b.year);
+
+    // Get the two most recent years
+    const current = sortedData[sortedData.length - 1];
+    const previous = sortedData[sortedData.length - 2];
+
+    // Calculate growth rate
+    return ((current.population - previous.population) / previous.population) * 100;
+  }
+
+  // Get key metrics for the dashboard
+  async getKeyMetrics(): Promise<PopulationMetricData[]> {
+    const trendData = await this.getPopulationTrend();
+    const growthRate = await this.getPopulationGrowthRate();
+
+    // Sort by year in ascending order
+    const sortedData = [...trendData].sort((a, b) => a.year - b.year);
+
+    if (sortedData.length < 2) {
+      return [];
+    }
+
+    // Get the two most recent years
+    const current = sortedData[sortedData.length - 1];
+    const previous = sortedData[sortedData.length - 2];
+
+    // Format population numbers
+    const formatter = new Intl.NumberFormat('en-US');
+
+    return [
+      {
+        title: 'Total Population',
+        value: formatter.format(current.population),
+        previousValue: formatter.format(previous.population),
+        change: ((current.population - previous.population) / previous.population) * 100,
+        changeType: current.population - previous.population > 0 ? 'positive' : 'negative',
+        unit: '',
+      },
+      {
+        title: 'Growth Rate',
+        value: `${growthRate.toFixed(2)}%`,
+        changeType: growthRate > 0 ? 'positive' : 'negative',
+        unit: '%',
+      },
+      {
+        title: 'Current Year',
+        value: current.year,
+        previousValue: previous.year,
+        unit: '',
+      },
+    ];
+  }
+
+  // Get all available years from the dataset
+  async getAvailableYears(): Promise<number[]> {
+    const nationalData = await this.getNationalPopulationData();
+    const years = nationalData.map(item => parseInt(item.Year));
+    return [...new Set(years)].sort((a, b) => b - a); // Sort years in descending order
+  }
+
+  // Get all state names from the dataset
+  async getAvailableStates(): Promise<string[]> {
+    const stateData = await this.getStatePopulationData();
+    const states = stateData.map(item => item.State);
+    return [...new Set(states)].sort(); // Sort states alphabetically
+  }
+}
+
+export default new USPopulationDataProvider();

--- a/src/pages/us-population-dashboard/data-provider.ts
+++ b/src/pages/us-population-dashboard/data-provider.ts
@@ -14,6 +14,8 @@ const BASE_URL = 'https://datausa.io/api/data';
 class USPopulationDataProvider {
   // Fetch national population data
   async getNationalPopulationData(): Promise<PopulationData[]> {
+    console.log('Fetching national population data');
+
     const params = new URLSearchParams({
       drilldowns: 'Nation',
       measures: 'Population',
@@ -30,6 +32,8 @@ class USPopulationDataProvider {
 
   // Fetch state population data
   async getStatePopulationData(): Promise<StatePopulationData[]> {
+    console.log('Fetching state population data');
+
     const params = new URLSearchParams({
       drilldowns: 'State',
       measures: 'Population',
@@ -46,6 +50,8 @@ class USPopulationDataProvider {
 
   // Get population trend data (formatted for charts)
   async getPopulationTrend(): Promise<PopulationTrendData[]> {
+    console.log('Getting population trend data');
+
     const nationalData = await this.getNationalPopulationData();
 
     // Sort by year (ascending)
@@ -57,8 +63,10 @@ class USPopulationDataProvider {
     }));
   }
 
-  // Get population data by state (for the most recent available year)
+  // Get population data by state (for the most recent available year or specified year)
   async getPopulationByState(year?: number): Promise<PopulationByStateData[]> {
+    console.log('Getting population by state data for year:', year);
+
     const stateData = await this.getStatePopulationData();
 
     // Filter by specified year or get the most recent year
@@ -66,9 +74,11 @@ class USPopulationDataProvider {
     if (!targetYear) {
       const years = stateData.map(item => parseInt(item.Year));
       targetYear = Math.max(...years);
+      console.log('No year specified, using most recent year:', targetYear);
     }
 
     const filteredData = stateData.filter(item => parseInt(item.Year) === targetYear);
+    console.log(`Found ${filteredData.length} states for year ${targetYear}`);
 
     return filteredData.map(item => ({
       state: item.State,
@@ -79,6 +89,8 @@ class USPopulationDataProvider {
 
   // Calculate population growth rate
   async getPopulationGrowthRate(): Promise<number> {
+    console.log('Calculating population growth rate');
+
     const trendData = await this.getPopulationTrend();
 
     if (trendData.length < 2) {
@@ -93,11 +105,16 @@ class USPopulationDataProvider {
     const previous = sortedData[sortedData.length - 2];
 
     // Calculate growth rate
-    return ((current.population - previous.population) / previous.population) * 100;
+    const growthRate = ((current.population - previous.population) / previous.population) * 100;
+    console.log(`Growth rate calculated: ${growthRate.toFixed(2)}%`);
+
+    return growthRate;
   }
 
   // Get key metrics for the dashboard
   async getKeyMetrics(): Promise<PopulationMetricData[]> {
+    console.log('Getting key metrics');
+
     const trendData = await this.getPopulationTrend();
     const growthRate = await this.getPopulationGrowthRate();
 
@@ -141,16 +158,26 @@ class USPopulationDataProvider {
 
   // Get all available years from the dataset
   async getAvailableYears(): Promise<number[]> {
+    console.log('Getting available years');
+
     const nationalData = await this.getNationalPopulationData();
     const years = nationalData.map(item => parseInt(item.Year));
-    return [...new Set(years)].sort((a, b) => b - a); // Sort years in descending order
+    const uniqueSortedYears = [...new Set(years)].sort((a, b) => b - a); // Sort years in descending order
+
+    console.log('Available years:', uniqueSortedYears);
+    return uniqueSortedYears;
   }
 
   // Get all state names from the dataset
   async getAvailableStates(): Promise<string[]> {
+    console.log('Getting available states');
+
     const stateData = await this.getStatePopulationData();
     const states = stateData.map(item => item.State);
-    return [...new Set(states)].sort(); // Sort states alphabetically
+    const uniqueSortedStates = [...new Set(states)].sort(); // Sort states alphabetically
+
+    console.log(`Found ${uniqueSortedStates.length} unique states`);
+    return uniqueSortedStates;
   }
 }
 

--- a/src/pages/us-population-dashboard/index.tsx
+++ b/src/pages/us-population-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function USPopulationDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/us-population-dashboard/interfaces.ts
+++ b/src/pages/us-population-dashboard/interfaces.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface PopulationData {
+  'ID Nation': string;
+  Nation: string;
+  'ID Year': number;
+  Year: string;
+  Population: number;
+  'Slug Nation': string;
+}
+
+export interface StatePopulationData {
+  'ID State': string;
+  State: string;
+  'ID Year': number;
+  Year: string;
+  Population: number;
+  'Slug State': string;
+}
+
+export interface PopulationTrendData {
+  year: number;
+  population: number;
+}
+
+export interface PopulationByStateData {
+  state: string;
+  population: number;
+  year: number;
+}
+
+export interface PopulationMetricData {
+  title: string;
+  value: string | number;
+  previousValue?: string | number;
+  change?: number;
+  changeType?: 'positive' | 'negative' | 'neutral';
+  unit?: string;
+}
+
+export interface FilterState {
+  selectedYears: number[];
+  selectedStates: string[];
+  comparisonYear: number | null;
+}


### PR DESCRIPTION
Adds a new US Population Dashboard demo showcasing data visualization capabilities using Cloudscape components. The dashboard includes:

- Interactive population metrics cards
- Population trend bar chart
- State-by-state population table with filtering
- Population distribution pie chart
- Year and state selection filters

The demo integrates with the DataUSA API to display real US Census Bureau data.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=quantum-verse&projectId=98bf2453a9fe441eb6778cbc07f519aa)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->