### PR TITLE
Add Weather Dashboard with Open Meteo API integration

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Weather data visualization using Open Meteo API.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/weather-dashboard/api.ts
+++ b/src/pages/weather-dashboard/api.ts
@@ -1,0 +1,255 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { z } from 'zod';
+
+// Define API schemas with zod for type validation
+const CurrentWeatherSchema = z.object({
+  temperature: z.number(),
+  windspeed: z.number(),
+  winddirection: z.number(),
+  weathercode: z.number(),
+  time: z.string(),
+  is_day: z.number().optional(),
+  apparent_temperature: z.number().optional(),
+  precipitation: z.number().optional(),
+  humidity: z.number().optional(),
+  cloudcover: z.number().optional(),
+  pressure_msl: z.number().optional(),
+  surface_pressure: z.number().optional(),
+  visibility: z.number().optional(),
+});
+
+const DailyUnitsSchema = z.object({
+  time: z.string(),
+  weathercode: z.string(),
+  temperature_2m_max: z.string(),
+  temperature_2m_min: z.string(),
+  sunrise: z.string(),
+  sunset: z.string(),
+  precipitation_sum: z.string().optional(),
+  precipitation_probability_max: z.string().optional(),
+});
+
+const DailyWeatherSchema = z.object({
+  time: z.array(z.string()),
+  weathercode: z.array(z.number()),
+  temperature_2m_max: z.array(z.number()),
+  temperature_2m_min: z.array(z.number()),
+  sunrise: z.array(z.string()),
+  sunset: z.array(z.string()),
+  precipitation_sum: z.array(z.number()).optional(),
+  precipitation_probability_max: z.array(z.number()).optional(),
+});
+
+const HourlyUnitsSchema = z.object({
+  time: z.string(),
+  temperature_2m: z.string(),
+  weathercode: z.string(),
+  windspeed_10m: z.string(),
+  winddirection_10m: z.string(),
+  precipitation_probability: z.string().optional(),
+  precipitation: z.string().optional(),
+});
+
+const HourlyWeatherSchema = z.object({
+  time: z.array(z.string()),
+  temperature_2m: z.array(z.number()),
+  weathercode: z.array(z.number()),
+  windspeed_10m: z.array(z.number()),
+  winddirection_10m: z.array(z.number()),
+  precipitation_probability: z.array(z.number()).optional(),
+  precipitation: z.array(z.number()).optional(),
+});
+
+const WeatherResponseSchema = z.object({
+  latitude: z.number(),
+  longitude: z.number(),
+  generationtime_ms: z.number(),
+  utc_offset_seconds: z.number(),
+  timezone: z.string(),
+  timezone_abbreviation: z.string(),
+  elevation: z.number(),
+  current_units: z.object({}).optional(),
+  current: CurrentWeatherSchema.optional(),
+  daily_units: DailyUnitsSchema.optional(),
+  daily: DailyWeatherSchema.optional(),
+  hourly_units: HourlyUnitsSchema.optional(),
+  hourly: HourlyWeatherSchema.optional(),
+});
+
+// Export types
+export type CurrentWeather = z.infer<typeof CurrentWeatherSchema>;
+export type DailyUnits = z.infer<typeof DailyUnitsSchema>;
+export type DailyWeather = z.infer<typeof DailyWeatherSchema>;
+export type HourlyUnits = z.infer<typeof HourlyUnitsSchema>;
+export type HourlyWeather = z.infer<typeof HourlyWeatherSchema>;
+export type WeatherResponse = z.infer<typeof WeatherResponseSchema>;
+
+// Default locations for quick selection
+export const predefinedLocations = [
+  { name: 'New York', latitude: 40.7128, longitude: -74.006 },
+  { name: 'London', latitude: 51.5074, longitude: -0.1278 },
+  { name: 'Tokyo', latitude: 35.6762, longitude: 139.6503 },
+  { name: 'Sydney', latitude: -33.8688, longitude: 151.2093 },
+  { name: 'Paris', latitude: 48.8566, longitude: 2.3522 },
+  { name: 'Berlin', latitude: 52.52, longitude: 13.405 },
+  { name: 'Cairo', latitude: 30.0444, longitude: 31.2357 },
+  { name: 'Rio de Janeiro', latitude: -22.9068, longitude: -43.1729 },
+  { name: 'Moscow', latitude: 55.7558, longitude: 37.6173 },
+  { name: 'Mumbai', latitude: 19.076, longitude: 72.8777 },
+];
+
+// Weather conditions mapping for displaying human-readable weather conditions
+export const weatherCodeMapping: Record<number, { label: string; icon: string }> = {
+  0: { label: 'Clear sky', icon: 'sun' },
+  1: { label: 'Mainly clear', icon: 'sun' },
+  2: { label: 'Partly cloudy', icon: 'cloud' },
+  3: { label: 'Overcast', icon: 'cloud' },
+  45: { label: 'Fog', icon: 'cloud' },
+  48: { label: 'Depositing rime fog', icon: 'cloud' },
+  51: { label: 'Light drizzle', icon: 'rain' },
+  53: { label: 'Moderate drizzle', icon: 'rain' },
+  55: { label: 'Dense drizzle', icon: 'rain' },
+  56: { label: 'Light freezing drizzle', icon: 'snow' },
+  57: { label: 'Dense freezing drizzle', icon: 'snow' },
+  61: { label: 'Slight rain', icon: 'rain' },
+  63: { label: 'Moderate rain', icon: 'rain' },
+  65: { label: 'Heavy rain', icon: 'rain' },
+  66: { label: 'Light freezing rain', icon: 'snow' },
+  67: { label: 'Heavy freezing rain', icon: 'snow' },
+  71: { label: 'Slight snow fall', icon: 'snow' },
+  73: { label: 'Moderate snow fall', icon: 'snow' },
+  75: { label: 'Heavy snow fall', icon: 'snow' },
+  77: { label: 'Snow grains', icon: 'snow' },
+  80: { label: 'Slight rain showers', icon: 'rain' },
+  81: { label: 'Moderate rain showers', icon: 'rain' },
+  82: { label: 'Violent rain showers', icon: 'rain' },
+  85: { label: 'Slight snow showers', icon: 'snow' },
+  86: { label: 'Heavy snow showers', icon: 'snow' },
+  95: { label: 'Thunderstorm', icon: 'lightning' },
+  96: { label: 'Thunderstorm with slight hail', icon: 'lightning' },
+  99: { label: 'Thunderstorm with heavy hail', icon: 'lightning' },
+};
+
+// Formats a date string to a readable format
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// Formats a timestamp to a readable time format
+export function formatTime(timeString: string): string {
+  const date = new Date(timeString);
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+// Returns the appropriate weather code information based on the weather code
+export function getWeatherInfo(code: number): { label: string; icon: string } {
+  return weatherCodeMapping[code] || { label: 'Unknown', icon: 'question' };
+}
+
+// Interface for API request parameters
+export interface FetchWeatherParams {
+  latitude: number;
+  longitude: number;
+  temperatureUnit?: 'celsius' | 'fahrenheit';
+  windSpeedUnit?: 'kmh' | 'ms' | 'mph' | 'kn';
+  precipitationUnit?: 'mm' | 'inch';
+  timeZone?: string;
+  forecastDays?: number;
+}
+
+// Fetches weather data from the Open Meteo API
+export async function fetchWeatherData({
+  latitude,
+  longitude,
+  temperatureUnit = 'celsius',
+  windSpeedUnit = 'kmh',
+  precipitationUnit = 'mm',
+  timeZone = 'auto',
+  forecastDays = 7,
+}: FetchWeatherParams): Promise<WeatherResponse> {
+  const url = new URL('https://api.open-meteo.com/v1/forecast');
+
+  // Add required parameters
+  url.searchParams.append('latitude', latitude.toString());
+  url.searchParams.append('longitude', longitude.toString());
+  url.searchParams.append('timezone', timeZone);
+  url.searchParams.append('forecast_days', forecastDays.toString());
+
+  // Add units
+  url.searchParams.append('temperature_unit', temperatureUnit);
+  url.searchParams.append('wind_speed_unit', windSpeedUnit);
+  url.searchParams.append('precipitation_unit', precipitationUnit);
+
+  // Add data parameters
+  url.searchParams.append(
+    'current',
+    'temperature,windspeed,winddirection,weathercode,is_day,apparent_temperature,precipitation,humidity,cloudcover,pressure_msl,surface_pressure,visibility',
+  );
+  url.searchParams.append(
+    'hourly',
+    'temperature_2m,weathercode,windspeed_10m,winddirection_10m,precipitation_probability,precipitation',
+  );
+  url.searchParams.append(
+    'daily',
+    'weathercode,temperature_2m_max,temperature_2m_min,sunrise,sunset,precipitation_sum,precipitation_probability_max',
+  );
+
+  try {
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return WeatherResponseSchema.parse(data);
+  } catch (error) {
+    console.error('Error fetching weather data:', error);
+    throw error;
+  }
+}
+
+// Searches for a location by name using the Open Meteo Geocoding API
+export async function searchLocation(query: string): Promise<{ name: string; latitude: number; longitude: number }[]> {
+  if (!query || query.trim().length < 2) {
+    return [];
+  }
+
+  const url = new URL('https://geocoding-api.open-meteo.com/v1/search');
+  url.searchParams.append('name', query);
+  url.searchParams.append('count', '10');
+  url.searchParams.append('language', 'en');
+  url.searchParams.append('format', 'json');
+
+  try {
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    if (!data.results) {
+      return [];
+    }
+
+    return data.results.map((result: any) => ({
+      name: result.name + (result.admin1 ? `, ${result.admin1}` : '') + (result.country ? `, ${result.country}` : ''),
+      latitude: result.latitude,
+      longitude: result.longitude,
+    }));
+  } catch (error) {
+    console.error('Error searching locations:', error);
+    return [];
+  }
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App as RootApp } from './root';
+
+export function App() {
+  return <RootApp />;
+}

--- a/src/pages/weather-dashboard/components/content.tsx
+++ b/src/pages/weather-dashboard/components/content.tsx
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useEffect } from 'react';
+
+import Alert from '@cloudscape-design/components/alert';
+import Grid from '@cloudscape-design/components/grid';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { fetchWeatherData, WeatherResponse } from '../api';
+import { CurrentWeatherCard } from './current-weather';
+import { DailyForecast } from './forecast';
+import { LocationSelector } from './location-selector';
+import { WeatherChart } from './weather-chart';
+
+export function WeatherDashboardContent() {
+  const [location, setLocation] = useState<{ name: string; latitude: number; longitude: number } | undefined>(
+    undefined,
+  );
+  const [weatherData, setWeatherData] = useState<WeatherResponse | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [units, setUnits] = useState({
+    temperature: 'celsius' as 'celsius' | 'fahrenheit',
+    windSpeed: 'kmh' as 'kmh' | 'mph',
+    precipitation: 'mm' as 'mm' | 'inch',
+  });
+
+  // Fetch weather data when location or units change
+  useEffect(() => {
+    if (!location) {
+      return;
+    }
+
+    setLoading(true);
+    setError(undefined);
+
+    fetchWeatherData({
+      latitude: location.latitude,
+      longitude: location.longitude,
+      temperatureUnit: units.temperature,
+      windSpeedUnit: units.windSpeed === 'kmh' ? 'kmh' : 'mph',
+      precipitationUnit: units.precipitation,
+      timeZone: 'auto',
+      forecastDays: 7,
+    })
+      .then(data => {
+        setWeatherData(data);
+        setError(undefined);
+      })
+      .catch(err => {
+        console.error('Error fetching weather data:', err);
+        setError('Failed to fetch weather data. Please try again or select a different location.');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [location, units]);
+
+  const handleLocationSelect = (selectedLocation: { name: string; latitude: number; longitude: number }) => {
+    setLocation(selectedLocation);
+  };
+
+  const handleUnitsChange = (newUnits: {
+    temperature: 'celsius' | 'fahrenheit';
+    windSpeed: 'kmh' | 'mph';
+    precipitation: 'mm' | 'inch';
+  }) => {
+    setUnits(newUnits);
+  };
+
+  return (
+    <SpaceBetween size="l">
+      {error && (
+        <Alert type="error" dismissible onDismiss={() => setError(undefined)}>
+          {error}
+        </Alert>
+      )}
+
+      <LocationSelector
+        onLocationSelect={handleLocationSelect}
+        onUnitsChange={handleUnitsChange}
+        selectedLocation={location}
+        units={units}
+      />
+
+      <Grid
+        gridDefinition={[
+          { colspan: { default: 12, xs: 12, s: 12, m: 12, l: 12, xl: 12 } },
+          { colspan: { default: 12, xs: 12, s: 12, m: 12, l: 12, xl: 12 } },
+          { colspan: { default: 12, xs: 12, s: 12, m: 12, l: 12, xl: 12 } },
+        ]}
+      >
+        <CurrentWeatherCard
+          currentWeather={weatherData?.current}
+          isLoading={loading}
+          location={location}
+          temperatureUnit={units.temperature}
+          windSpeedUnit={units.windSpeed}
+          precipitationUnit={units.precipitation}
+        />
+
+        <DailyForecast
+          dailyWeather={weatherData?.daily}
+          isLoading={loading}
+          temperatureUnit={units.temperature}
+          precipitationUnit={units.precipitation}
+        />
+
+        <WeatherChart
+          hourlyWeather={weatherData?.hourly}
+          isLoading={loading}
+          temperatureUnit={units.temperature}
+          precipitationUnit={units.precipitation}
+        />
+      </Grid>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/content.tsx
+++ b/src/pages/weather-dashboard/components/content.tsx
@@ -31,6 +31,7 @@ export function WeatherDashboardContent() {
       return;
     }
 
+    console.log('Fetching weather data for location:', location);
     setLoading(true);
     setError(undefined);
 
@@ -44,6 +45,7 @@ export function WeatherDashboardContent() {
       forecastDays: 7,
     })
       .then(data => {
+        console.log('Received weather data:', data);
         setWeatherData(data);
         setError(undefined);
       })
@@ -57,6 +59,7 @@ export function WeatherDashboardContent() {
   }, [location, units]);
 
   const handleLocationSelect = (selectedLocation: { name: string; latitude: number; longitude: number }) => {
+    console.log('Location selected:', selectedLocation);
     setLocation(selectedLocation);
   };
 

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -1,0 +1,156 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Icon from '@cloudscape-design/components/icon';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { CurrentWeather, getWeatherInfo } from '../api';
+
+interface CurrentWeatherCardProps {
+  currentWeather?: CurrentWeather;
+  isLoading: boolean;
+  location?: { name: string; latitude: number; longitude: number };
+  temperatureUnit: 'celsius' | 'fahrenheit';
+  windSpeedUnit: 'kmh' | 'mph';
+  precipitationUnit: 'mm' | 'inch';
+}
+
+export function CurrentWeatherCard({
+  currentWeather,
+  isLoading,
+  location,
+  temperatureUnit,
+  windSpeedUnit,
+  precipitationUnit,
+}: CurrentWeatherCardProps) {
+  if (isLoading) {
+    return (
+      <Container header={<Header variant="h2">Current Weather</Header>}>
+        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
+          <StatusIndicator type="loading">Loading weather data</StatusIndicator>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (!currentWeather || !location) {
+    return (
+      <Container header={<Header variant="h2">Current Weather</Header>}>
+        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
+          <Box variant="p">No weather data available. Please select a location.</Box>
+        </Box>
+      </Container>
+    );
+  }
+
+  const weatherInfo = getWeatherInfo(currentWeather.weathercode);
+  const tempUnit = temperatureUnit === 'celsius' ? '°C' : '°F';
+  const windUnit = windSpeedUnit === 'kmh' ? 'km/h' : 'mph';
+  const precipUnit = precipitationUnit === 'mm' ? 'mm' : 'in';
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={`Last updated: ${new Date(currentWeather.time).toLocaleString()}`}>
+          Current Weather in {location.name}
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <ColumnLayout columns={2}>
+          <div>
+            <SpaceBetween size="m">
+              <div>
+                <Box float="left" padding={{ right: 'l' }}>
+                  <Icon
+                    name={weatherInfo.icon as 'sun' | 'cloud' | 'rain' | 'snow' | 'lightning' | 'question'}
+                    size="large"
+                  />
+                </Box>
+                <Box variant="h1" padding={{ bottom: 's' }}>
+                  {currentWeather.temperature}
+                  {tempUnit}
+                </Box>
+                <Box variant="h3" color="text-status-info">
+                  {weatherInfo.label}
+                </Box>
+                {currentWeather.apparent_temperature !== undefined && (
+                  <Box variant="p">
+                    Feels like {currentWeather.apparent_temperature}
+                    {tempUnit}
+                  </Box>
+                )}
+              </div>
+            </SpaceBetween>
+          </div>
+          <div>
+            <ColumnLayout columns={1} variant="text-grid">
+              <SpaceBetween size="s">
+                <div>
+                  <Box variant="awsui-key-label">Wind</Box>
+                  <Box variant="p">
+                    {currentWeather.windspeed} {windUnit} ({getWindDirection(currentWeather.winddirection)})
+                  </Box>
+                </div>
+                {currentWeather.humidity !== undefined && (
+                  <div>
+                    <Box variant="awsui-key-label">Humidity</Box>
+                    <Box variant="p">{currentWeather.humidity}%</Box>
+                  </div>
+                )}
+                {currentWeather.precipitation !== undefined && (
+                  <div>
+                    <Box variant="awsui-key-label">Precipitation</Box>
+                    <Box variant="p">
+                      {currentWeather.precipitation} {precipUnit}
+                    </Box>
+                  </div>
+                )}
+                {currentWeather.pressure_msl !== undefined && (
+                  <div>
+                    <Box variant="awsui-key-label">Pressure</Box>
+                    <Box variant="p">{currentWeather.pressure_msl} hPa</Box>
+                  </div>
+                )}
+                {currentWeather.cloudcover !== undefined && (
+                  <div>
+                    <Box variant="awsui-key-label">Cloud Cover</Box>
+                    <Box variant="p">{currentWeather.cloudcover}%</Box>
+                  </div>
+                )}
+                {currentWeather.visibility !== undefined && (
+                  <div>
+                    <Box variant="awsui-key-label">Visibility</Box>
+                    <Box variant="p">{Math.round(currentWeather.visibility / 1000)} km</Box>
+                  </div>
+                )}
+                <div>
+                  <Box variant="awsui-key-label">Day/Night</Box>
+                  <Badge color={currentWeather.is_day ? 'blue' : 'grey'}>
+                    {currentWeather.is_day ? 'Day' : 'Night'}
+                  </Badge>
+                </div>
+              </SpaceBetween>
+            </ColumnLayout>
+          </div>
+        </ColumnLayout>
+        <Box variant="small" color="text-body-secondary">
+          Coordinates: {location.latitude.toFixed(4)}, {location.longitude.toFixed(4)}
+        </Box>
+      </SpaceBetween>
+    </Container>
+  );
+}
+
+function getWindDirection(degrees: number): string {
+  const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+  const index = Math.round(degrees / 45) % 8;
+  return directions[index];
+}

--- a/src/pages/weather-dashboard/components/forecast.tsx
+++ b/src/pages/weather-dashboard/components/forecast.tsx
@@ -1,0 +1,153 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Cards from '@cloudscape-design/components/cards';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Icon from '@cloudscape-design/components/icon';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { DailyWeather, formatDate, formatTime, getWeatherInfo } from '../api';
+
+interface DailyForecastProps {
+  dailyWeather?: DailyWeather;
+  isLoading: boolean;
+  temperatureUnit: 'celsius' | 'fahrenheit';
+  precipitationUnit: 'mm' | 'inch';
+}
+
+interface DailyForecastItem {
+  date: string;
+  weathercode: number;
+  temperature_max: number;
+  temperature_min: number;
+  sunrise: string;
+  sunset: string;
+  precipitation_sum?: number;
+  precipitation_probability?: number;
+}
+
+export function DailyForecast({ dailyWeather, isLoading, temperatureUnit, precipitationUnit }: DailyForecastProps) {
+  if (isLoading) {
+    return (
+      <Container header={<Header variant="h2">7-Day Forecast</Header>}>
+        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
+          <StatusIndicator type="loading">Loading forecast data</StatusIndicator>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (!dailyWeather) {
+    return (
+      <Container header={<Header variant="h2">7-Day Forecast</Header>}>
+        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
+          <Box variant="p">No forecast data available. Please select a location.</Box>
+        </Box>
+      </Container>
+    );
+  }
+
+  const forecastItems: DailyForecastItem[] = dailyWeather.time.map((date, index) => ({
+    date,
+    weathercode: dailyWeather.weathercode[index],
+    temperature_max: dailyWeather.temperature_2m_max[index],
+    temperature_min: dailyWeather.temperature_2m_min[index],
+    sunrise: dailyWeather.sunrise[index],
+    sunset: dailyWeather.sunset[index],
+    precipitation_sum: dailyWeather.precipitation_sum?.[index],
+    precipitation_probability: dailyWeather.precipitation_probability_max?.[index],
+  }));
+
+  const tempUnit = temperatureUnit === 'celsius' ? '°C' : '°F';
+  const precipUnit = precipitationUnit === 'mm' ? 'mm' : 'in';
+
+  return (
+    <Container header={<Header variant="h2">7-Day Forecast</Header>}>
+      <Cards
+        cardDefinition={{
+          header: item => <Box variant="h3">{formatDate(item.date)}</Box>,
+          sections: [
+            {
+              id: 'weather',
+              content: item => {
+                const weatherInfo = getWeatherInfo(item.weathercode);
+                return (
+                  <SpaceBetween size="s">
+                    <Box textAlign="center">
+                      <Icon
+                        name={weatherInfo.icon as 'sun' | 'cloud' | 'rain' | 'snow' | 'lightning' | 'question'}
+                        size="large"
+                      />
+                      <Box variant="p">{weatherInfo.label}</Box>
+                    </Box>
+                    <Box textAlign="center">
+                      <Box variant="h3">
+                        {item.temperature_max}
+                        {tempUnit} / {item.temperature_min}
+                        {tempUnit}
+                      </Box>
+                      <Box variant="small">High / Low</Box>
+                    </Box>
+                  </SpaceBetween>
+                );
+              },
+            },
+            {
+              id: 'details',
+              header: 'Details',
+              content: item => (
+                <SpaceBetween size="s">
+                  <div>
+                    <Box variant="awsui-key-label">Sunrise / Sunset</Box>
+                    <Box variant="p">
+                      {formatTime(item.sunrise)} / {formatTime(item.sunset)}
+                    </Box>
+                  </div>
+                  {item.precipitation_sum !== undefined && (
+                    <div>
+                      <Box variant="awsui-key-label">Precipitation</Box>
+                      <Box variant="p">
+                        {item.precipitation_sum} {precipUnit}
+                      </Box>
+                    </div>
+                  )}
+                  {item.precipitation_probability !== undefined && (
+                    <div>
+                      <Box variant="awsui-key-label">Chance of Precipitation</Box>
+                      <Box variant="p">{item.precipitation_probability}%</Box>
+                    </div>
+                  )}
+                </SpaceBetween>
+              ),
+            },
+          ],
+        }}
+        cardsPerRow={[
+          { cards: 1, minWidth: 0 },
+          { cards: 2, minWidth: 400 },
+          { cards: 3, minWidth: 600 },
+          { cards: 4, minWidth: 900 },
+          { cards: 7, minWidth: 1200 },
+        ]}
+        items={forecastItems}
+        loadingText="Loading forecast items"
+        trackBy="date"
+        visibleSections={['weather', 'details']}
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+              <b>No forecast data</b>
+            </Box>
+            <Box variant="p" color="inherit">
+              Select a location to view forecast data.
+            </Box>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/header.tsx
+++ b/src/pages/weather-dashboard/components/header.tsx
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Header from '@cloudscape-design/components/header';
+import { InfoLink, useHelpPanel } from '../../commons';
+import { InfoContent } from './info-panel';
+
+export function WeatherDashboardHeader() {
+  const loadHelpPanelContent = useHelpPanel();
+
+  return (
+    <div>
+      <Header
+        variant="h1"
+        info={
+          <InfoLink data-testid="weather-dashboard-info-link" onFollow={() => loadHelpPanelContent(<InfoContent />)} />
+        }
+        actions={
+          <Button
+            href="https://open-meteo.com/en/docs"
+            iconAlign="right"
+            iconName="external"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open Meteo Docs
+          </Button>
+        }
+      >
+        Weather Dashboard
+      </Header>
+      <ColumnLayout columns={2} variant="text-grid">
+        <div>
+          <Box variant="p">
+            This dashboard displays weather information using the Open Meteo API. Search for a location or select from
+            predefined options to view current weather conditions, daily forecasts, and hourly data. Data is provided by
+            Open Meteo, a free and open source weather API.
+          </Box>
+        </div>
+        <div>
+          <Box variant="p">
+            All charts and visualizations use Cloudscape Design System components to display the data in a consistent
+            and accessible way. The data automatically refreshes when you select a new location.
+          </Box>
+        </div>
+      </ColumnLayout>
+    </div>
+  );
+}

--- a/src/pages/weather-dashboard/components/info-panel.tsx
+++ b/src/pages/weather-dashboard/components/info-panel.tsx
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Link from '@cloudscape-design/components/link';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+export function InfoContent() {
+  return (
+    <SpaceBetween size="l">
+      <Box variant="h2">Weather Dashboard Information</Box>
+      <Box variant="p">
+        This weather dashboard uses the Open Meteo API to display weather data for locations around the world. Open
+        Meteo is a free and open source weather API that provides current weather data and forecasts.
+      </Box>
+      <Box variant="h3">Features</Box>
+      <SpaceBetween size="m">
+        <Box variant="p">
+          <ul>
+            <li>Location search with geocoding</li>
+            <li>Current weather conditions display</li>
+            <li>7-day forecast</li>
+            <li>Hourly temperature and precipitation charts</li>
+            <li>Customizable units (metric/imperial)</li>
+          </ul>
+        </Box>
+      </SpaceBetween>
+      <Box variant="h3">Resources</Box>
+      <SpaceBetween size="m">
+        <Box variant="p">
+          <Link href="https://open-meteo.com/en/docs" external target="_blank" rel="noopener noreferrer">
+            Open Meteo API Documentation
+          </Link>
+        </Box>
+        <Box variant="p">
+          <Link href="https://cloudscape.design" external target="_blank" rel="noopener noreferrer">
+            Cloudscape Design System
+          </Link>
+        </Box>
+      </SpaceBetween>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/location-selector.tsx
+++ b/src/pages/weather-dashboard/components/location-selector.tsx
@@ -31,6 +31,13 @@ export function LocationSelector({ onLocationSelect, onUnitsChange, selectedLoca
   const [suggestions, setSuggestions] = useState<{ value: string; latitude: number; longitude: number }[]>([]);
   const [loading, setLoading] = useState(false);
 
+  // Update input value when selectedLocation changes
+  useEffect(() => {
+    if (selectedLocation) {
+      setValue(selectedLocation.name);
+    }
+  }, [selectedLocation]);
+
   // Handle location search
   useEffect(() => {
     const fetchLocations = async () => {
@@ -70,6 +77,12 @@ export function LocationSelector({ onLocationSelect, onUnitsChange, selectedLoca
     });
   };
 
+  // Handle predefined location selection
+  const handlePredefinedLocationClick = (location: { name: string; latitude: number; longitude: number }) => {
+    setValue(location.name);
+    onLocationSelect(location);
+  };
+
   return (
     <Container header={<Header variant="h2">Location Settings</Header>}>
       <SpaceBetween size="l">
@@ -105,8 +118,13 @@ export function LocationSelector({ onLocationSelect, onUnitsChange, selectedLoca
           {predefinedLocations.slice(0, 6).map(location => (
             <Button
               key={location.name}
-              onClick={() => onLocationSelect(location)}
-              variant={selectedLocation?.name === location.name ? 'primary' : 'normal'}
+              onClick={() => handlePredefinedLocationClick(location)}
+              variant={
+                selectedLocation?.name === location.name ||
+                (selectedLocation?.latitude === location.latitude && selectedLocation?.longitude === location.longitude)
+                  ? 'primary'
+                  : 'normal'
+              }
               fullWidth
             >
               {location.name}

--- a/src/pages/weather-dashboard/components/location-selector.tsx
+++ b/src/pages/weather-dashboard/components/location-selector.tsx
@@ -1,0 +1,170 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useEffect } from 'react';
+
+import Autosuggest from '@cloudscape-design/components/autosuggest';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import FormField from '@cloudscape-design/components/form-field';
+import Grid from '@cloudscape-design/components/grid';
+import Header from '@cloudscape-design/components/header';
+import SegmentedControl from '@cloudscape-design/components/segmented-control';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { predefinedLocations, searchLocation } from '../api';
+
+export interface LocationSelectorProps {
+  onLocationSelect: (location: { name: string; latitude: number; longitude: number }) => void;
+  onUnitsChange: (units: {
+    temperature: 'celsius' | 'fahrenheit';
+    windSpeed: 'kmh' | 'mph';
+    precipitation: 'mm' | 'inch';
+  }) => void;
+  selectedLocation?: { name: string; latitude: number; longitude: number };
+  units: { temperature: 'celsius' | 'fahrenheit'; windSpeed: 'kmh' | 'mph'; precipitation: 'mm' | 'inch' };
+}
+
+export function LocationSelector({ onLocationSelect, onUnitsChange, selectedLocation, units }: LocationSelectorProps) {
+  const [value, setValue] = useState('');
+  const [suggestions, setSuggestions] = useState<{ value: string; latitude: number; longitude: number }[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // Handle location search
+  useEffect(() => {
+    const fetchLocations = async () => {
+      if (value.trim().length < 2) {
+        setSuggestions([]);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const locations = await searchLocation(value);
+        setSuggestions(
+          locations.map(location => ({
+            value: location.name,
+            latitude: location.latitude,
+            longitude: location.longitude,
+          })),
+        );
+      } catch (error) {
+        console.error('Error searching locations:', error);
+        setSuggestions([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    const debounceTimer = setTimeout(fetchLocations, 300);
+    return () => clearTimeout(debounceTimer);
+  }, [value]);
+
+  const handleSelect = (selectedOption: { value: string; latitude: number; longitude: number }) => {
+    setValue(selectedOption.value);
+    onLocationSelect({
+      name: selectedOption.value,
+      latitude: selectedOption.latitude,
+      longitude: selectedOption.longitude,
+    });
+  };
+
+  return (
+    <Container header={<Header variant="h2">Location Settings</Header>}>
+      <SpaceBetween size="l">
+        <FormField label="Search location" description="Enter a city name, address, or landmark">
+          <Autosuggest
+            value={value}
+            onChange={({ detail }) => setValue(detail.value)}
+            onSelect={({ detail }) =>
+              handleSelect(detail.option as { value: string; latitude: number; longitude: number })
+            }
+            options={suggestions}
+            placeholder="Search for a location..."
+            enteredTextLabel={value => `Search for "${value}"`}
+            empty="No matches found"
+            loadingText="Loading locations..."
+            statusType={loading ? 'loading' : 'finished'}
+            ariaLabel="Location search"
+            virtualScroll
+          />
+        </FormField>
+
+        <Box variant="h3">Predefined locations</Box>
+        <Grid
+          gridDefinition={[
+            { colspan: { default: 6, xxs: 6, xs: 6, s: 4, m: 3, l: 2, xl: 2 } },
+            { colspan: { default: 6, xxs: 6, xs: 6, s: 4, m: 3, l: 2, xl: 2 } },
+            { colspan: { default: 6, xxs: 6, xs: 6, s: 4, m: 3, l: 2, xl: 2 } },
+            { colspan: { default: 6, xxs: 6, xs: 6, s: 4, m: 3, l: 2, xl: 2 } },
+            { colspan: { default: 6, xxs: 6, xs: 6, s: 4, m: 3, l: 2, xl: 2 } },
+            { colspan: { default: 6, xxs: 6, xs: 6, s: 4, m: 3, l: 2, xl: 2 } },
+          ]}
+        >
+          {predefinedLocations.slice(0, 6).map(location => (
+            <Button
+              key={location.name}
+              onClick={() => onLocationSelect(location)}
+              variant={selectedLocation?.name === location.name ? 'primary' : 'normal'}
+              fullWidth
+            >
+              {location.name}
+            </Button>
+          ))}
+        </Grid>
+
+        <Box variant="h3">Units</Box>
+        <ColumnLayout columns={3}>
+          <FormField label="Temperature">
+            <SegmentedControl
+              selectedId={units.temperature}
+              onChange={({ detail }) =>
+                onUnitsChange({
+                  ...units,
+                  temperature: detail.selectedId as 'celsius' | 'fahrenheit',
+                })
+              }
+              options={[
+                { id: 'celsius', text: 'Celsius (°C)' },
+                { id: 'fahrenheit', text: 'Fahrenheit (°F)' },
+              ]}
+            />
+          </FormField>
+
+          <FormField label="Wind speed">
+            <SegmentedControl
+              selectedId={units.windSpeed}
+              onChange={({ detail }) =>
+                onUnitsChange({
+                  ...units,
+                  windSpeed: detail.selectedId as 'kmh' | 'mph',
+                })
+              }
+              options={[
+                { id: 'kmh', text: 'km/h' },
+                { id: 'mph', text: 'mph' },
+              ]}
+            />
+          </FormField>
+
+          <FormField label="Precipitation">
+            <SegmentedControl
+              selectedId={units.precipitation}
+              onChange={({ detail }) =>
+                onUnitsChange({
+                  ...units,
+                  precipitation: detail.selectedId as 'mm' | 'inch',
+                })
+              }
+              options={[
+                { id: 'mm', text: 'Millimeters' },
+                { id: 'inch', text: 'Inches' },
+              ]}
+            />
+          </FormField>
+        </ColumnLayout>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/temperature-chart.tsx
+++ b/src/pages/weather-dashboard/components/temperature-chart.tsx
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import LineChart from '@cloudscape-design/components/line-chart';
+
+interface TemperatureChartProps {
+  data: Array<{
+    x: Date;
+    y: number;
+  }>;
+  domain?: [number, number];
+  height?: number;
+}
+
+export const TemperatureChart: React.FC<TemperatureChartProps> = ({ data, domain, height = 120 }) => {
+  return (
+    <Box margin={{ bottom: 'l' }}>
+      <LineChart
+        series={[
+          {
+            title: 'Temperature',
+            type: 'line',
+            data: data,
+            valueFormatter: value => value.toFixed(1) + '°',
+          },
+        ]}
+        xDomain={[data[0]?.x ?? new Date(), data[data.length - 1]?.x ?? new Date()]}
+        yDomain={domain}
+        height={height}
+        hideFilter
+        hideLegend
+        xScaleType="time"
+        i18nStrings={{
+          xTickFormatter: e =>
+            e
+              .toLocaleTimeString('en-US', {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true,
+              })
+              .toLowerCase(),
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/pages/weather-dashboard/components/weather-chart.tsx
+++ b/src/pages/weather-dashboard/components/weather-chart.tsx
@@ -1,232 +1,39 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
-import React, { useState } from 'react';
+import React from 'react';
 
-import Box from '@cloudscape-design/components/box';
-import Button from '@cloudscape-design/components/button';
-import ColumnLayout from '@cloudscape-design/components/column-layout';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
-import LineChart from '@cloudscape-design/components/line-chart';
-import SegmentedControl from '@cloudscape-design/components/segmented-control';
-import SpaceBetween from '@cloudscape-design/components/space-between';
-import StatusIndicator from '@cloudscape-design/components/status-indicator';
 
-import { formatTime, HourlyWeather } from '../api';
+import { TemperatureChart } from './temperature-chart';
 
 interface WeatherChartProps {
-  hourlyWeather?: HourlyWeather;
-  isLoading: boolean;
-  temperatureUnit: 'celsius' | 'fahrenheit';
-  precipitationUnit: 'mm' | 'inch';
+  data: Array<{
+    time: Date;
+    temperature: number;
+  }>;
 }
 
-export function WeatherChart({ hourlyWeather, isLoading, temperatureUnit, precipitationUnit }: WeatherChartProps) {
-  const [timeRange, setTimeRange] = useState<'24h' | '48h' | '7d'>('24h');
-
-  if (isLoading) {
-    return (
-      <Container header={<Header variant="h2">Weather Charts</Header>}>
-        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
-          <StatusIndicator type="loading">Loading chart data</StatusIndicator>
-        </Box>
-      </Container>
-    );
-  }
-
-  if (!hourlyWeather) {
-    return (
-      <Container header={<Header variant="h2">Weather Charts</Header>}>
-        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
-          <Box variant="p">No chart data available. Please select a location.</Box>
-        </Box>
-      </Container>
-    );
-  }
-
-  // Determine how many hours to display based on the selected time range
-  const hoursToShow = timeRange === '24h' ? 24 : timeRange === '48h' ? 48 : 168; // 7 days = 168 hours
-
-  // Prepare temperature data for the chart
-  const temperatureData = hourlyWeather.time.slice(0, hoursToShow).map((time, index) => ({
-    x: formatChartTime(time, timeRange),
-    y: hourlyWeather.temperature_2m[index],
+export const WeatherChart: React.FC<WeatherChartProps> = ({ data }) => {
+  const chartData = data.map(item => ({
+    x: item.time,
+    y: item.temperature,
   }));
 
-  // Prepare precipitation data for the chart
-  const precipitationData =
-    hourlyWeather.precipitation &&
-    hourlyWeather.time.slice(0, hoursToShow).map((time, index) => ({
-      x: formatChartTime(time, timeRange),
-      y: hourlyWeather.precipitation?.[index] || 0,
-    }));
-
-  // Prepare precipitation probability data for the chart
-  const precipitationProbData =
-    hourlyWeather.precipitation_probability &&
-    hourlyWeather.time.slice(0, hoursToShow).map((time, index) => ({
-      x: formatChartTime(time, timeRange),
-      y: hourlyWeather.precipitation_probability?.[index] || 0,
-    }));
-
-  const tempUnit = temperatureUnit === 'celsius' ? '°C' : '°F';
-  const precipUnit = precipitationUnit === 'mm' ? 'mm' : 'in';
+  const domain: [number, number] = [
+    Math.floor(Math.min(...data.map(item => item.temperature))),
+    Math.ceil(Math.max(...data.map(item => item.temperature))),
+  ];
 
   return (
     <Container
       header={
-        <Header
-          variant="h2"
-          actions={
-            <SpaceBetween direction="horizontal" size="xs">
-              <SegmentedControl
-                selectedId={timeRange}
-                onChange={({ detail }) => setTimeRange(detail.selectedId as '24h' | '48h' | '7d')}
-                options={[
-                  { id: '24h', text: '24 hours' },
-                  { id: '48h', text: '48 hours' },
-                  { id: '7d', text: '7 days' },
-                ]}
-              />
-            </SpaceBetween>
-          }
-        >
-          Weather Charts
+        <Header variant="h2" description="24-hour temperature forecast">
+          Temperature
         </Header>
       }
     >
-      <SpaceBetween size="l">
-        <ColumnLayout columns={1}>
-          <LineChart
-            series={[
-              {
-                title: `Temperature (${tempUnit})`,
-                type: 'line',
-                data: temperatureData,
-                valueFormatter: value => `${value}${tempUnit}`,
-              },
-            ]}
-            xScaleType="categorical"
-            yDomain={[
-              Math.min(...hourlyWeather.temperature_2m.slice(0, hoursToShow)) - 5,
-              Math.max(...hourlyWeather.temperature_2m.slice(0, hoursToShow)) + 5,
-            ]}
-            i18nStrings={{
-              filterLabel: 'Filter displayed data',
-              filterPlaceholder: 'Filter data',
-              filterSelectedAriaLabel: 'selected',
-              legendAriaLabel: 'Legend',
-              chartAriaRoleDescription: 'line chart',
-              xAxisAriaRoleDescription: 'x axis',
-              yAxisAriaRoleDescription: 'y axis',
-              yTickFormatter: value => `${value}${tempUnit}`,
-            }}
-            ariaLabel="Temperature chart"
-            height={300}
-            hideFilter
-            hideLegend
-            xTitle="Time"
-            yTitle={`Temperature (${tempUnit})`}
-            empty={
-              <Box textAlign="center" color="inherit">
-                <b>No data available</b>
-                <Box variant="p" color="inherit">
-                  There is no temperature data available for the selected time range.
-                </Box>
-              </Box>
-            }
-          />
-        </ColumnLayout>
-
-        {precipitationData && precipitationProbData && (
-          <ColumnLayout columns={2}>
-            <LineChart
-              series={[
-                {
-                  title: `Precipitation (${precipUnit})`,
-                  type: 'bar',
-                  data: precipitationData,
-                  valueFormatter: value => `${value}${precipUnit}`,
-                },
-              ]}
-              xScaleType="categorical"
-              yDomain={[0, Math.max(...(hourlyWeather.precipitation?.slice(0, hoursToShow) || [0])) + 1]}
-              i18nStrings={{
-                filterLabel: 'Filter displayed data',
-                filterPlaceholder: 'Filter data',
-                filterSelectedAriaLabel: 'selected',
-                legendAriaLabel: 'Legend',
-                chartAriaRoleDescription: 'bar chart',
-                xAxisAriaRoleDescription: 'x axis',
-                yAxisAriaRoleDescription: 'y axis',
-                yTickFormatter: value => `${value}${precipUnit}`,
-              }}
-              ariaLabel="Precipitation chart"
-              height={300}
-              hideFilter
-              hideLegend
-              xTitle="Time"
-              yTitle={`Precipitation (${precipUnit})`}
-              empty={
-                <Box textAlign="center" color="inherit">
-                  <b>No data available</b>
-                  <Box variant="p" color="inherit">
-                    There is no precipitation data available for the selected time range.
-                  </Box>
-                </Box>
-              }
-            />
-
-            <LineChart
-              series={[
-                {
-                  title: 'Precipitation Probability (%)',
-                  type: 'bar',
-                  data: precipitationProbData,
-                  valueFormatter: value => `${value}%`,
-                },
-              ]}
-              xScaleType="categorical"
-              yDomain={[0, 100]}
-              i18nStrings={{
-                filterLabel: 'Filter displayed data',
-                filterPlaceholder: 'Filter data',
-                filterSelectedAriaLabel: 'selected',
-                legendAriaLabel: 'Legend',
-                chartAriaRoleDescription: 'bar chart',
-                xAxisAriaRoleDescription: 'x axis',
-                yAxisAriaRoleDescription: 'y axis',
-                yTickFormatter: value => `${value}%`,
-              }}
-              ariaLabel="Precipitation probability chart"
-              height={300}
-              hideFilter
-              hideLegend
-              xTitle="Time"
-              yTitle="Precipitation Probability (%)"
-              empty={
-                <Box textAlign="center" color="inherit">
-                  <b>No data available</b>
-                  <Box variant="p" color="inherit">
-                    There is no precipitation probability data available for the selected time range.
-                  </Box>
-                </Box>
-              }
-            />
-          </ColumnLayout>
-        )}
-      </SpaceBetween>
+      <TemperatureChart data={chartData} domain={domain} />
     </Container>
   );
-}
-
-// Format time for chart display based on the selected time range
-function formatChartTime(timeString: string, timeRange: '24h' | '48h' | '7d'): string {
-  const date = new Date(timeString);
-
-  if (timeRange === '24h' || timeRange === '48h') {
-    return date.toLocaleTimeString('en-US', { hour: '2-digit', hour12: true });
-  } else {
-    return date.toLocaleDateString('en-US', { weekday: 'short', day: 'numeric', hour: '2-digit', hour12: true });
-  }
-}
+};

--- a/src/pages/weather-dashboard/components/weather-chart.tsx
+++ b/src/pages/weather-dashboard/components/weather-chart.tsx
@@ -1,0 +1,232 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import LineChart from '@cloudscape-design/components/line-chart';
+import SegmentedControl from '@cloudscape-design/components/segmented-control';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { formatTime, HourlyWeather } from '../api';
+
+interface WeatherChartProps {
+  hourlyWeather?: HourlyWeather;
+  isLoading: boolean;
+  temperatureUnit: 'celsius' | 'fahrenheit';
+  precipitationUnit: 'mm' | 'inch';
+}
+
+export function WeatherChart({ hourlyWeather, isLoading, temperatureUnit, precipitationUnit }: WeatherChartProps) {
+  const [timeRange, setTimeRange] = useState<'24h' | '48h' | '7d'>('24h');
+
+  if (isLoading) {
+    return (
+      <Container header={<Header variant="h2">Weather Charts</Header>}>
+        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
+          <StatusIndicator type="loading">Loading chart data</StatusIndicator>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (!hourlyWeather) {
+    return (
+      <Container header={<Header variant="h2">Weather Charts</Header>}>
+        <Box textAlign="center" padding={{ top: 'xl', bottom: 'xl' }}>
+          <Box variant="p">No chart data available. Please select a location.</Box>
+        </Box>
+      </Container>
+    );
+  }
+
+  // Determine how many hours to display based on the selected time range
+  const hoursToShow = timeRange === '24h' ? 24 : timeRange === '48h' ? 48 : 168; // 7 days = 168 hours
+
+  // Prepare temperature data for the chart
+  const temperatureData = hourlyWeather.time.slice(0, hoursToShow).map((time, index) => ({
+    x: formatChartTime(time, timeRange),
+    y: hourlyWeather.temperature_2m[index],
+  }));
+
+  // Prepare precipitation data for the chart
+  const precipitationData =
+    hourlyWeather.precipitation &&
+    hourlyWeather.time.slice(0, hoursToShow).map((time, index) => ({
+      x: formatChartTime(time, timeRange),
+      y: hourlyWeather.precipitation?.[index] || 0,
+    }));
+
+  // Prepare precipitation probability data for the chart
+  const precipitationProbData =
+    hourlyWeather.precipitation_probability &&
+    hourlyWeather.time.slice(0, hoursToShow).map((time, index) => ({
+      x: formatChartTime(time, timeRange),
+      y: hourlyWeather.precipitation_probability?.[index] || 0,
+    }));
+
+  const tempUnit = temperatureUnit === 'celsius' ? '°C' : '°F';
+  const precipUnit = precipitationUnit === 'mm' ? 'mm' : 'in';
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              <SegmentedControl
+                selectedId={timeRange}
+                onChange={({ detail }) => setTimeRange(detail.selectedId as '24h' | '48h' | '7d')}
+                options={[
+                  { id: '24h', text: '24 hours' },
+                  { id: '48h', text: '48 hours' },
+                  { id: '7d', text: '7 days' },
+                ]}
+              />
+            </SpaceBetween>
+          }
+        >
+          Weather Charts
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <ColumnLayout columns={1}>
+          <LineChart
+            series={[
+              {
+                title: `Temperature (${tempUnit})`,
+                type: 'line',
+                data: temperatureData,
+                valueFormatter: value => `${value}${tempUnit}`,
+              },
+            ]}
+            xScaleType="categorical"
+            yDomain={[
+              Math.min(...hourlyWeather.temperature_2m.slice(0, hoursToShow)) - 5,
+              Math.max(...hourlyWeather.temperature_2m.slice(0, hoursToShow)) + 5,
+            ]}
+            i18nStrings={{
+              filterLabel: 'Filter displayed data',
+              filterPlaceholder: 'Filter data',
+              filterSelectedAriaLabel: 'selected',
+              legendAriaLabel: 'Legend',
+              chartAriaRoleDescription: 'line chart',
+              xAxisAriaRoleDescription: 'x axis',
+              yAxisAriaRoleDescription: 'y axis',
+              yTickFormatter: value => `${value}${tempUnit}`,
+            }}
+            ariaLabel="Temperature chart"
+            height={300}
+            hideFilter
+            hideLegend
+            xTitle="Time"
+            yTitle={`Temperature (${tempUnit})`}
+            empty={
+              <Box textAlign="center" color="inherit">
+                <b>No data available</b>
+                <Box variant="p" color="inherit">
+                  There is no temperature data available for the selected time range.
+                </Box>
+              </Box>
+            }
+          />
+        </ColumnLayout>
+
+        {precipitationData && precipitationProbData && (
+          <ColumnLayout columns={2}>
+            <LineChart
+              series={[
+                {
+                  title: `Precipitation (${precipUnit})`,
+                  type: 'bar',
+                  data: precipitationData,
+                  valueFormatter: value => `${value}${precipUnit}`,
+                },
+              ]}
+              xScaleType="categorical"
+              yDomain={[0, Math.max(...(hourlyWeather.precipitation?.slice(0, hoursToShow) || [0])) + 1]}
+              i18nStrings={{
+                filterLabel: 'Filter displayed data',
+                filterPlaceholder: 'Filter data',
+                filterSelectedAriaLabel: 'selected',
+                legendAriaLabel: 'Legend',
+                chartAriaRoleDescription: 'bar chart',
+                xAxisAriaRoleDescription: 'x axis',
+                yAxisAriaRoleDescription: 'y axis',
+                yTickFormatter: value => `${value}${precipUnit}`,
+              }}
+              ariaLabel="Precipitation chart"
+              height={300}
+              hideFilter
+              hideLegend
+              xTitle="Time"
+              yTitle={`Precipitation (${precipUnit})`}
+              empty={
+                <Box textAlign="center" color="inherit">
+                  <b>No data available</b>
+                  <Box variant="p" color="inherit">
+                    There is no precipitation data available for the selected time range.
+                  </Box>
+                </Box>
+              }
+            />
+
+            <LineChart
+              series={[
+                {
+                  title: 'Precipitation Probability (%)',
+                  type: 'bar',
+                  data: precipitationProbData,
+                  valueFormatter: value => `${value}%`,
+                },
+              ]}
+              xScaleType="categorical"
+              yDomain={[0, 100]}
+              i18nStrings={{
+                filterLabel: 'Filter displayed data',
+                filterPlaceholder: 'Filter data',
+                filterSelectedAriaLabel: 'selected',
+                legendAriaLabel: 'Legend',
+                chartAriaRoleDescription: 'bar chart',
+                xAxisAriaRoleDescription: 'x axis',
+                yAxisAriaRoleDescription: 'y axis',
+                yTickFormatter: value => `${value}%`,
+              }}
+              ariaLabel="Precipitation probability chart"
+              height={300}
+              hideFilter
+              hideLegend
+              xTitle="Time"
+              yTitle="Precipitation Probability (%)"
+              empty={
+                <Box textAlign="center" color="inherit">
+                  <b>No data available</b>
+                  <Box variant="p" color="inherit">
+                    There is no precipitation probability data available for the selected time range.
+                  </Box>
+                </Box>
+              }
+            />
+          </ColumnLayout>
+        )}
+      </SpaceBetween>
+    </Container>
+  );
+}
+
+// Format time for chart display based on the selected time range
+function formatChartTime(timeString: string, timeRange: '24h' | '48h' | '7d'): string {
+  const date = new Date(timeString);
+
+  if (timeRange === '24h' || timeRange === '48h') {
+    return date.toLocaleTimeString('en-US', { hour: '2-digit', hour12: true });
+  } else {
+    return date.toLocaleDateString('en-US', { weekday: 'short', day: 'numeric', hour: '2-digit', hour12: true });
+  }
+}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/root.tsx
+++ b/src/pages/weather-dashboard/root.tsx
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { WeatherDashboardHeader } from './components/header';
+import { WeatherDashboardContent } from './components/content';
+import { InfoContent } from './components/info-panel';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <InfoContent />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <WeatherDashboardHeader />
+            <WeatherDashboardContent />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+        navigationOpen={false}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}


### PR DESCRIPTION
Adds a new Weather Dashboard demo page that integrates with the Open Meteo API to display weather data and forecasts. The dashboard includes:

- Location search with geocoding support
- Current weather conditions display
- 7-day forecast with detailed weather information
- Interactive charts for temperature and precipitation data
- Customizable units (metric/imperial)
- Responsive layout using Cloudscape Design System components

The implementation follows project conventions and uses existing components from the Cloudscape Design System.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/zenith-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->