### PR TITLE
Add Weather Dashboard demo page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/weather',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather data and forecasts.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/weather/app.tsx
+++ b/src/pages/weather/app.tsx
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Flashbar, { FlashbarProps } from '@cloudscape-design/components/flashbar';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Navigation } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { ForecastTable } from './components/forecast-table';
+import { LocationSearch } from './components/location-search';
+import { WeatherCard } from './components/weather-card';
+import { LocationData, WeatherData, WeatherService } from './weather-service';
+
+export function App() {
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [selectedLocation, setSelectedLocation] = useState<LocationData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [notifications, setNotifications] = useState<FlashbarProps.MessageDefinition[]>([]);
+
+  const handleLocationSelect = async (location: LocationData) => {
+    setLoading(true);
+    setSelectedLocation(location);
+
+    try {
+      const weather = await WeatherService.getCurrentWeather(location.latitude, location.longitude);
+      setWeatherData(weather);
+
+      // Show success notification
+      setNotifications([
+        {
+          type: 'success',
+          content: `Weather data loaded for ${location.name}`,
+          dismissible: true,
+          onDismiss: () => setNotifications([]),
+          id: 'weather-success',
+        },
+      ]);
+    } catch (error) {
+      console.error('Error fetching weather:', error);
+
+      // Show error notification
+      setNotifications([
+        {
+          type: 'error',
+          content: 'Failed to fetch weather data. Please try again.',
+          dismissible: true,
+          onDismiss: () => setNotifications([]),
+          id: 'weather-error',
+        },
+      ]);
+
+      setWeatherData(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRefresh = () => {
+    if (selectedLocation) {
+      handleLocationSelect(selectedLocation);
+    }
+  };
+
+  const getLocationDisplayName = (location: LocationData) => {
+    if (location.name === 'Current Location') {
+      return 'Current Location';
+    }
+    return location.admin1
+      ? `${location.name}, ${location.admin1}, ${location.country}`
+      : `${location.name}, ${location.country}`;
+  };
+
+  return (
+    <CustomAppLayout
+      content={
+        <SpaceBetween size="l">
+          <Header
+            variant="h1"
+            description="Real-time weather data and forecasts powered by Open Meteo API"
+            actions={
+              weatherData && (
+                <Button onClick={handleRefresh} loading={loading} iconName="refresh">
+                  Refresh
+                </Button>
+              )
+            }
+          >
+            Weather Dashboard
+          </Header>
+
+          <LocationSearch onLocationSelect={handleLocationSelect} loading={loading} />
+
+          {loading && <div style={{ textAlign: 'center', padding: '20px' }}>Loading weather data...</div>}
+
+          {weatherData && selectedLocation && (
+            <SpaceBetween size="l">
+              <WeatherCard weather={weatherData} locationName={getLocationDisplayName(selectedLocation)} />
+              <ForecastTable weather={weatherData} />
+            </SpaceBetween>
+          )}
+        </SpaceBetween>
+      }
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Home', href: '/' },
+            { text: 'Weather Dashboard', href: '/weather' },
+          ]}
+          expandAriaLabel="Show path"
+          ariaLabel="Breadcrumbs"
+        />
+      }
+      notifications={<Flashbar items={notifications} stackItems={true} />}
+      navigation={<Navigation activeHref="/weather" />}
+      navigationOpen={false}
+      toolsHide={true}
+    />
+  );
+}

--- a/src/pages/weather/components/forecast-table.tsx
+++ b/src/pages/weather/components/forecast-table.tsx
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Tabs from '@cloudscape-design/components/tabs';
+
+import { WeatherData, WeatherService } from '../weather-service';
+
+interface ForecastTableProps {
+  weather: WeatherData;
+}
+
+export function ForecastTable({ weather }: ForecastTableProps) {
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString([], {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const hourlyData = weather.hourly.slice(0, 24);
+
+  return (
+    <Container header={<Header variant="h2">Weather Forecast</Header>}>
+      <Tabs
+        tabs={[
+          {
+            label: 'Hourly (24h)',
+            id: 'hourly',
+            content: (
+              <Table
+                columnDefinitions={[
+                  {
+                    id: 'time',
+                    header: 'Time',
+                    cell: item => formatTime(item.time),
+                    sortingField: 'time',
+                  },
+                  {
+                    id: 'weather',
+                    header: 'Weather',
+                    cell: item => (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        <span style={{ fontSize: '1.2em' }}>{WeatherService.getWeatherIcon(item.weatherCode)}</span>
+                        <span>{WeatherService.getWeatherDescription(item.weatherCode)}</span>
+                      </div>
+                    ),
+                  },
+                  {
+                    id: 'temperature',
+                    header: 'Temperature',
+                    cell: item => `${item.temperature}°C`,
+                    sortingField: 'temperature',
+                  },
+                  {
+                    id: 'humidity',
+                    header: 'Humidity',
+                    cell: item => `${item.humidity}%`,
+                    sortingField: 'humidity',
+                  },
+                  {
+                    id: 'precipitation',
+                    header: 'Precipitation',
+                    cell: item => `${item.precipitation} mm`,
+                    sortingField: 'precipitation',
+                  },
+                ]}
+                items={hourlyData}
+                loadingText="Loading forecast"
+                trackBy="time"
+                empty="No forecast data available"
+                sortingDisabled={false}
+              />
+            ),
+          },
+          {
+            label: 'Daily (7 days)',
+            id: 'daily',
+            content: (
+              <Table
+                columnDefinitions={[
+                  {
+                    id: 'date',
+                    header: 'Date',
+                    cell: item => formatDate(item.date),
+                    sortingField: 'date',
+                  },
+                  {
+                    id: 'weather',
+                    header: 'Weather',
+                    cell: item => (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        <span style={{ fontSize: '1.2em' }}>{WeatherService.getWeatherIcon(item.weatherCode)}</span>
+                        <span>{WeatherService.getWeatherDescription(item.weatherCode)}</span>
+                      </div>
+                    ),
+                  },
+                  {
+                    id: 'temperatureMax',
+                    header: 'High',
+                    cell: item => `${item.temperatureMax}°C`,
+                    sortingField: 'temperatureMax',
+                  },
+                  {
+                    id: 'temperatureMin',
+                    header: 'Low',
+                    cell: item => `${item.temperatureMin}°C`,
+                    sortingField: 'temperatureMin',
+                  },
+                  {
+                    id: 'precipitation',
+                    header: 'Precipitation',
+                    cell: item => `${item.precipitationSum} mm`,
+                    sortingField: 'precipitationSum',
+                  },
+                ]}
+                items={weather.daily}
+                loadingText="Loading forecast"
+                trackBy="date"
+                empty="No forecast data available"
+                sortingDisabled={false}
+              />
+            ),
+          },
+        ]}
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather/components/forecast-table.tsx
+++ b/src/pages/weather/components/forecast-table.tsx
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT-0
 import React from 'react';
 
+import Box from '@cloudscape-design/components/box';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
 import Table from '@cloudscape-design/components/table';
 import Tabs from '@cloudscape-design/components/tabs';
 
@@ -88,49 +90,63 @@ export function ForecastTable({ weather }: ForecastTableProps) {
             label: 'Daily (7 days)',
             id: 'daily',
             content: (
-              <Table
-                columnDefinitions={[
-                  {
-                    id: 'date',
-                    header: 'Date',
-                    cell: item => formatDate(item.date),
-                    sortingField: 'date',
-                  },
-                  {
-                    id: 'weather',
-                    header: 'Weather',
-                    cell: item => (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                        <span style={{ fontSize: '1.2em' }}>{WeatherService.getWeatherIcon(item.weatherCode)}</span>
-                        <span>{WeatherService.getWeatherDescription(item.weatherCode)}</span>
-                      </div>
-                    ),
-                  },
-                  {
-                    id: 'temperatureMax',
-                    header: 'High',
-                    cell: item => `${item.temperatureMax}°C`,
-                    sortingField: 'temperatureMax',
-                  },
-                  {
-                    id: 'temperatureMin',
-                    header: 'Low',
-                    cell: item => `${item.temperatureMin}°C`,
-                    sortingField: 'temperatureMin',
-                  },
-                  {
-                    id: 'precipitation',
-                    header: 'Precipitation',
-                    cell: item => `${item.precipitationSum} mm`,
-                    sortingField: 'precipitationSum',
-                  },
-                ]}
-                items={weather.daily}
-                loadingText="Loading forecast"
-                trackBy="date"
-                empty="No forecast data available"
-                sortingDisabled={false}
-              />
+              <div
+                style={{
+                  overflowX: 'auto',
+                  padding: '8px 0',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: '16px',
+                    minWidth: 'max-content',
+                    paddingBottom: '8px',
+                  }}
+                >
+                  {weather.daily.map((day, index) => (
+                    <div
+                      key={day.date}
+                      style={{
+                        minWidth: '160px',
+                        padding: '16px',
+                        border: '1px solid #e0e0e0',
+                        borderRadius: '8px',
+                        backgroundColor: '#fafafa',
+                        textAlign: 'center',
+                        flexShrink: 0,
+                      }}
+                    >
+                      <SpaceBetween size="xs">
+                        <Box variant="h4" fontWeight="bold">
+                          {index === 0 ? 'Today' : formatDate(day.date)}
+                        </Box>
+
+                        <Box fontSize="heading-xl">{WeatherService.getWeatherIcon(day.weatherCode)}</Box>
+
+                        <Box fontSize="body-s" color="text-status-info">
+                          {WeatherService.getWeatherDescription(day.weatherCode)}
+                        </Box>
+
+                        <SpaceBetween size="xxs">
+                          <Box fontSize="heading-s" fontWeight="bold">
+                            {day.temperatureMax}°C
+                          </Box>
+                          <Box fontSize="body-s" color="text-body-secondary">
+                            {day.temperatureMin}°C
+                          </Box>
+                        </SpaceBetween>
+
+                        {day.precipitationSum > 0 && (
+                          <Box fontSize="body-s" color="text-status-info">
+                            💧 {day.precipitationSum} mm
+                          </Box>
+                        )}
+                      </SpaceBetween>
+                    </div>
+                  ))}
+                </div>
+              </div>
             ),
           },
         ]}

--- a/src/pages/weather/components/location-search.tsx
+++ b/src/pages/weather/components/location-search.tsx
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useCallback, useEffect, useState } from 'react';
+
+import Autosuggest from '@cloudscape-design/components/autosuggest';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import Form from '@cloudscape-design/components/form';
+import FormField from '@cloudscape-design/components/form-field';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { LocationData, WeatherService } from '../weather-service';
+
+interface LocationSearchProps {
+  onLocationSelect: (location: LocationData) => void;
+  loading?: boolean;
+}
+
+export function LocationSearch({ onLocationSelect, loading }: LocationSearchProps) {
+  const [searchValue, setSearchValue] = useState('');
+  const [suggestions, setSuggestions] = useState<LocationData[]>([]);
+  const [suggestionsLoading, setSuggestionsLoading] = useState(false);
+
+  const loadSuggestions = useCallback(async (value: string) => {
+    if (!value.trim()) {
+      setSuggestions([]);
+      return;
+    }
+
+    setSuggestionsLoading(true);
+    try {
+      const locations = await WeatherService.searchLocations(value);
+      setSuggestions(locations);
+    } catch (error) {
+      console.error('Error loading suggestions:', error);
+      setSuggestions([]);
+    } finally {
+      setSuggestionsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      loadSuggestions(searchValue);
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [searchValue, loadSuggestions]);
+
+  const handleLocationSelect = (location: LocationData) => {
+    setSearchValue(`${location.name}, ${location.country}`);
+    setSuggestions([]);
+    onLocationSelect(location);
+  };
+
+  const handleCurrentLocation = () => {
+    if ('geolocation' in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        position => {
+          const location: LocationData = {
+            name: 'Current Location',
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+            country: '',
+          };
+          setSearchValue('Current Location');
+          onLocationSelect(location);
+        },
+        error => {
+          console.error('Error getting current location:', error);
+        },
+      );
+    }
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Search for a location to view its weather forecast">
+          Location Search
+        </Header>
+      }
+    >
+      <Form>
+        <SpaceBetween direction="vertical" size="m">
+          <FormField label="Search for a city or location">
+            <Autosuggest
+              onChange={({ detail }) => setSearchValue(detail.value)}
+              value={searchValue}
+              options={suggestions.map(location => ({
+                value: `${location.name}, ${location.country}`,
+                label: location.admin1
+                  ? `${location.name}, ${location.admin1}, ${location.country}`
+                  : `${location.name}, ${location.country}`,
+                description: `${location.latitude.toFixed(4)}, ${location.longitude.toFixed(4)}`,
+              }))}
+              onSelect={({ detail }) => {
+                const selectedLocation = suggestions.find(
+                  location => `${location.name}, ${location.country}` === detail.value,
+                );
+                if (selectedLocation) {
+                  handleLocationSelect(selectedLocation);
+                }
+              }}
+              placeholder="Enter city name..."
+              statusType={suggestionsLoading ? 'loading' : 'finished'}
+              loadingText="Searching locations..."
+              empty="No locations found"
+              ariaLabel="Search for locations"
+            />
+          </FormField>
+
+          <Box textAlign="center">
+            <Button onClick={handleCurrentLocation} iconName="location" disabled={loading}>
+              Use Current Location
+            </Button>
+          </Box>
+        </SpaceBetween>
+      </Form>
+    </Container>
+  );
+}

--- a/src/pages/weather/components/weather-card.tsx
+++ b/src/pages/weather/components/weather-card.tsx
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { WeatherData, WeatherService } from '../weather-service';
+
+interface WeatherCardProps {
+  weather: WeatherData;
+  locationName?: string;
+}
+
+export function WeatherCard({ weather, locationName }: WeatherCardProps) {
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getWindDirection = (degrees: number) => {
+    const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+    const index = Math.round(degrees / 45) % 8;
+    return directions[index];
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={locationName || weather.location}>
+          Current Weather
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          <Box fontSize="display-l" fontWeight="bold">
+            {weather.current.temperature}°C
+          </Box>
+          <Box fontSize="heading-xl">{WeatherService.getWeatherIcon(weather.current.weatherCode)}</Box>
+          <Box fontSize="heading-s">{WeatherService.getWeatherDescription(weather.current.weatherCode)}</Box>
+        </div>
+
+        <KeyValuePairs
+          columns={3}
+          items={[
+            {
+              label: 'Humidity',
+              value: `${weather.current.humidity}%`,
+            },
+            {
+              label: 'Wind Speed',
+              value: `${weather.current.windSpeed} km/h`,
+            },
+            {
+              label: 'Wind Direction',
+              value: `${getWindDirection(weather.current.windDirection)} (${weather.current.windDirection}°)`,
+            },
+            {
+              label: 'Last Updated',
+              value: formatTime(weather.current.time),
+            },
+            {
+              label: 'Coordinates',
+              value: `${weather.latitude.toFixed(4)}, ${weather.longitude.toFixed(4)}`,
+            },
+          ]}
+        />
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather/index.tsx
+++ b/src/pages/weather/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}

--- a/src/pages/weather/weather-service.ts
+++ b/src/pages/weather/weather-service.ts
@@ -1,0 +1,171 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface WeatherData {
+  location: string;
+  latitude: number;
+  longitude: number;
+  current: {
+    temperature: number;
+    humidity: number;
+    windSpeed: number;
+    windDirection: number;
+    weatherCode: number;
+    time: string;
+  };
+  hourly: Array<{
+    time: string;
+    temperature: number;
+    humidity: number;
+    precipitation: number;
+    weatherCode: number;
+  }>;
+  daily: Array<{
+    date: string;
+    temperatureMax: number;
+    temperatureMin: number;
+    precipitationSum: number;
+    weatherCode: number;
+  }>;
+}
+
+export interface LocationData {
+  name: string;
+  latitude: number;
+  longitude: number;
+  country: string;
+  admin1?: string;
+}
+
+const OPEN_METEO_BASE_URL = 'https://api.open-meteo.com/v1';
+const GEOCODING_URL = 'https://geocoding-api.open-meteo.com/v1';
+
+export class WeatherService {
+  static async searchLocations(query: string): Promise<LocationData[]> {
+    if (!query.trim()) return [];
+
+    try {
+      const response = await fetch(
+        `${GEOCODING_URL}/search?name=${encodeURIComponent(query)}&count=10&language=en&format=json`,
+      );
+
+      if (!response.ok) {
+        throw new Error('Failed to search locations');
+      }
+
+      const data = await response.json();
+
+      return (data.results || []).map((result: any) => ({
+        name: result.name,
+        latitude: result.latitude,
+        longitude: result.longitude,
+        country: result.country,
+        admin1: result.admin1,
+      }));
+    } catch (error) {
+      console.error('Error searching locations:', error);
+      return [];
+    }
+  }
+
+  static async getCurrentWeather(latitude: number, longitude: number): Promise<WeatherData> {
+    try {
+      const params = new URLSearchParams({
+        latitude: latitude.toString(),
+        longitude: longitude.toString(),
+        current: 'temperature_2m,relative_humidity_2m,wind_speed_10m,wind_direction_10m,weather_code',
+        hourly: 'temperature_2m,relative_humidity_2m,precipitation,weather_code',
+        daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code',
+        timezone: 'auto',
+        forecast_days: '7',
+      });
+
+      const response = await fetch(`${OPEN_METEO_BASE_URL}/forecast?${params}`);
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch weather data');
+      }
+
+      const data = await response.json();
+
+      return {
+        location: `${latitude.toFixed(2)}, ${longitude.toFixed(2)}`,
+        latitude,
+        longitude,
+        current: {
+          temperature: Math.round(data.current.temperature_2m),
+          humidity: data.current.relative_humidity_2m,
+          windSpeed: Math.round(data.current.wind_speed_10m),
+          windDirection: data.current.wind_direction_10m,
+          weatherCode: data.current.weather_code,
+          time: data.current.time,
+        },
+        hourly: data.hourly.time.slice(0, 24).map((time: string, index: number) => ({
+          time,
+          temperature: Math.round(data.hourly.temperature_2m[index]),
+          humidity: data.hourly.relative_humidity_2m[index],
+          precipitation: data.hourly.precipitation[index],
+          weatherCode: data.hourly.weather_code[index],
+        })),
+        daily: data.daily.time.map((date: string, index: number) => ({
+          date,
+          temperatureMax: Math.round(data.daily.temperature_2m_max[index]),
+          temperatureMin: Math.round(data.daily.temperature_2m_min[index]),
+          precipitationSum: data.daily.precipitation_sum[index],
+          weatherCode: data.daily.weather_code[index],
+        })),
+      };
+    } catch (error) {
+      console.error('Error fetching weather data:', error);
+      throw error;
+    }
+  }
+
+  static getWeatherDescription(code: number): string {
+    const descriptions: Record<number, string> = {
+      0: 'Clear sky',
+      1: 'Mainly clear',
+      2: 'Partly cloudy',
+      3: 'Overcast',
+      45: 'Fog',
+      48: 'Depositing rime fog',
+      51: 'Light drizzle',
+      53: 'Moderate drizzle',
+      55: 'Dense drizzle',
+      56: 'Light freezing drizzle',
+      57: 'Dense freezing drizzle',
+      61: 'Slight rain',
+      63: 'Moderate rain',
+      65: 'Heavy rain',
+      66: 'Light freezing rain',
+      67: 'Heavy freezing rain',
+      71: 'Slight snow fall',
+      73: 'Moderate snow fall',
+      75: 'Heavy snow fall',
+      77: 'Snow grains',
+      80: 'Slight rain showers',
+      81: 'Moderate rain showers',
+      82: 'Violent rain showers',
+      85: 'Slight snow showers',
+      86: 'Heavy snow showers',
+      95: 'Thunderstorm',
+      96: 'Thunderstorm with slight hail',
+      99: 'Thunderstorm with heavy hail',
+    };
+
+    return descriptions[code] || 'Unknown';
+  }
+
+  static getWeatherIcon(code: number): string {
+    if (code === 0) return '☀️';
+    if (code <= 3) return '⛅';
+    if (code <= 48) return '🌫️';
+    if (code <= 57) return '🌦️';
+    if (code <= 67) return '🌧️';
+    if (code <= 77) return '❄️';
+    if (code <= 82) return '🌦️';
+    if (code <= 86) return '🌨️';
+    if (code <= 99) return '⛈️';
+    return '🌤️';
+  }
+}


### PR DESCRIPTION
Adds a new Weather Dashboard demo page that showcases real-time weather data and forecasts using the Open Meteo API. The page includes:

- Location search with autocomplete
- Current weather display
- Hourly and daily forecasts
- Current location detection
- Responsive layout using Cloudscape components

The demo is added to the main navigation under the "Dashboards" category.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/pixel-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->