### PR TITLE
Add weather dashboard with Open-Meteo API

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const demos = [
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
   {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather data and forecasts using Open-Meteo API.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',

--- a/src/pages/weather-dashboard/api.ts
+++ b/src/pages/weather-dashboard/api.ts
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { WeatherData, LocationData, WeatherCodeMapping } from './types';
+
+const BASE_URL = 'https://api.open-meteo.com/v1';
+
+// Default locations for demo purposes
+export const DEFAULT_LOCATIONS: LocationData[] = [
+  { latitude: 52.52, longitude: 13.41, city: 'Berlin', country: 'Germany' },
+  { latitude: 40.7128, longitude: -74.006, city: 'New York', country: 'United States' },
+  { latitude: 35.6762, longitude: 139.6503, city: 'Tokyo', country: 'Japan' },
+  { latitude: 51.5074, longitude: -0.1278, city: 'London', country: 'United Kingdom' },
+  { latitude: 37.7749, longitude: -122.4194, city: 'San Francisco', country: 'United States' },
+];
+
+// Weather code mappings based on WMO standards
+export const WEATHER_CODES: WeatherCodeMapping = {
+  0: { description: 'Clear sky', icon: 'sunny' },
+  1: { description: 'Mainly clear', icon: 'mostly-sunny' },
+  2: { description: 'Partly cloudy', icon: 'partly-cloudy' },
+  3: { description: 'Overcast', icon: 'cloudy' },
+  45: { description: 'Fog', icon: 'fog' },
+  48: { description: 'Depositing rime fog', icon: 'fog' },
+  51: { description: 'Light drizzle', icon: 'light-rain' },
+  53: { description: 'Moderate drizzle', icon: 'rain' },
+  55: { description: 'Dense drizzle', icon: 'rain' },
+  56: { description: 'Light freezing drizzle', icon: 'sleet' },
+  57: { description: 'Dense freezing drizzle', icon: 'sleet' },
+  61: { description: 'Slight rain', icon: 'light-rain' },
+  63: { description: 'Moderate rain', icon: 'rain' },
+  65: { description: 'Heavy rain', icon: 'heavy-rain' },
+  66: { description: 'Light freezing rain', icon: 'sleet' },
+  67: { description: 'Heavy freezing rain', icon: 'sleet' },
+  71: { description: 'Slight snow fall', icon: 'snow' },
+  73: { description: 'Moderate snow fall', icon: 'snow' },
+  75: { description: 'Heavy snow fall', icon: 'snow' },
+  77: { description: 'Snow grains', icon: 'snow' },
+  80: { description: 'Slight rain showers', icon: 'rain' },
+  81: { description: 'Moderate rain showers', icon: 'rain' },
+  82: { description: 'Violent rain showers', icon: 'heavy-rain' },
+  85: { description: 'Slight snow showers', icon: 'snow' },
+  86: { description: 'Heavy snow showers', icon: 'snow' },
+  95: { description: 'Thunderstorm', icon: 'thunderstorm' },
+  96: { description: 'Thunderstorm with slight hail', icon: 'thunderstorm' },
+  99: { description: 'Thunderstorm with heavy hail', icon: 'thunderstorm' },
+};
+
+export async function fetchWeatherData(location: LocationData): Promise<WeatherData> {
+  const params = new URLSearchParams({
+    latitude: location.latitude.toString(),
+    longitude: location.longitude.toString(),
+    current: [
+      'temperature_2m',
+      'relative_humidity_2m',
+      'apparent_temperature',
+      'is_day',
+      'precipitation',
+      'weather_code',
+      'cloud_cover',
+      'pressure_msl',
+      'surface_pressure',
+      'wind_speed_10m',
+      'wind_direction_10m',
+      'wind_gusts_10m',
+    ].join(','),
+    hourly: [
+      'temperature_2m',
+      'relative_humidity_2m',
+      'precipitation_probability',
+      'precipitation',
+      'weather_code',
+      'cloud_cover',
+      'wind_speed_10m',
+      'wind_direction_10m',
+    ].join(','),
+    daily: [
+      'weather_code',
+      'temperature_2m_max',
+      'temperature_2m_min',
+      'apparent_temperature_max',
+      'apparent_temperature_min',
+      'sunrise',
+      'sunset',
+      'precipitation_sum',
+      'precipitation_probability_max',
+      'wind_speed_10m_max',
+      'wind_gusts_10m_max',
+    ].join(','),
+    timezone: 'auto',
+    forecast_days: '7',
+  });
+
+  const response = await fetch(`${BASE_URL}/forecast?${params}`);
+
+  if (!response.ok) {
+    throw new Error(`Weather API error: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export function getWeatherDescription(weatherCode: number): string {
+  return WEATHER_CODES[weatherCode]?.description || 'Unknown';
+}
+
+export function getWeatherIcon(weatherCode: number): string {
+  return WEATHER_CODES[weatherCode]?.icon || 'sunny';
+}
+
+export function formatTemperature(temp: number, unit: string = '°C'): string {
+  return `${Math.round(temp)}${unit}`;
+}
+
+export function formatPrecipitation(precipitation: number, unit: string = 'mm'): string {
+  return `${precipitation.toFixed(1)}${unit}`;
+}
+
+export function formatWindSpeed(speed: number, unit: string = 'km/h'): string {
+  return `${Math.round(speed)} ${unit}`;
+}
+
+export function formatWindDirection(direction: number): string {
+  const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+  const index = Math.round(direction / 45) % 8;
+  return directions[index];
+}
+
+export function formatHumidity(humidity: number): string {
+  return `${Math.round(humidity)}%`;
+}
+
+export function formatPressure(pressure: number, unit: string = 'hPa'): string {
+  return `${Math.round(pressure)} ${unit}`;
+}

--- a/src/pages/weather-dashboard/api.ts
+++ b/src/pages/weather-dashboard/api.ts
@@ -14,36 +14,36 @@ export const DEFAULT_LOCATIONS: LocationData[] = [
   { latitude: 37.7749, longitude: -122.4194, city: 'San Francisco', country: 'United States' },
 ];
 
-// Weather code mappings based on WMO standards
+// Weather code mappings based on WMO standards with emojis
 export const WEATHER_CODES: WeatherCodeMapping = {
-  0: { description: 'Clear sky', icon: 'sunny' },
-  1: { description: 'Mainly clear', icon: 'mostly-sunny' },
-  2: { description: 'Partly cloudy', icon: 'partly-cloudy' },
-  3: { description: 'Overcast', icon: 'cloudy' },
-  45: { description: 'Fog', icon: 'fog' },
-  48: { description: 'Depositing rime fog', icon: 'fog' },
-  51: { description: 'Light drizzle', icon: 'light-rain' },
-  53: { description: 'Moderate drizzle', icon: 'rain' },
-  55: { description: 'Dense drizzle', icon: 'rain' },
-  56: { description: 'Light freezing drizzle', icon: 'sleet' },
-  57: { description: 'Dense freezing drizzle', icon: 'sleet' },
-  61: { description: 'Slight rain', icon: 'light-rain' },
-  63: { description: 'Moderate rain', icon: 'rain' },
-  65: { description: 'Heavy rain', icon: 'heavy-rain' },
-  66: { description: 'Light freezing rain', icon: 'sleet' },
-  67: { description: 'Heavy freezing rain', icon: 'sleet' },
-  71: { description: 'Slight snow fall', icon: 'snow' },
-  73: { description: 'Moderate snow fall', icon: 'snow' },
-  75: { description: 'Heavy snow fall', icon: 'snow' },
-  77: { description: 'Snow grains', icon: 'snow' },
-  80: { description: 'Slight rain showers', icon: 'rain' },
-  81: { description: 'Moderate rain showers', icon: 'rain' },
-  82: { description: 'Violent rain showers', icon: 'heavy-rain' },
-  85: { description: 'Slight snow showers', icon: 'snow' },
-  86: { description: 'Heavy snow showers', icon: 'snow' },
-  95: { description: 'Thunderstorm', icon: 'thunderstorm' },
-  96: { description: 'Thunderstorm with slight hail', icon: 'thunderstorm' },
-  99: { description: 'Thunderstorm with heavy hail', icon: 'thunderstorm' },
+  0: { description: 'Clear sky', icon: '☀️' },
+  1: { description: 'Mainly clear', icon: '🌤️' },
+  2: { description: 'Partly cloudy', icon: '⛅' },
+  3: { description: 'Overcast', icon: '☁️' },
+  45: { description: 'Fog', icon: '🌫️' },
+  48: { description: 'Depositing rime fog', icon: '🌫️' },
+  51: { description: 'Light drizzle', icon: '🌦️' },
+  53: { description: 'Moderate drizzle', icon: '🌧️' },
+  55: { description: 'Dense drizzle', icon: '🌧️' },
+  56: { description: 'Light freezing drizzle', icon: '🌨️' },
+  57: { description: 'Dense freezing drizzle', icon: '🌨️' },
+  61: { description: 'Slight rain', icon: '🌦️' },
+  63: { description: 'Moderate rain', icon: '🌧️' },
+  65: { description: 'Heavy rain', icon: '🌧️' },
+  66: { description: 'Light freezing rain', icon: '🌨️' },
+  67: { description: 'Heavy freezing rain', icon: '🌨️' },
+  71: { description: 'Slight snow fall', icon: '🌨️' },
+  73: { description: 'Moderate snow fall', icon: '❄️' },
+  75: { description: 'Heavy snow fall', icon: '❄️' },
+  77: { description: 'Snow grains', icon: '🌨️' },
+  80: { description: 'Slight rain showers', icon: '🌦️' },
+  81: { description: 'Moderate rain showers', icon: '🌧️' },
+  82: { description: 'Violent rain showers', icon: '⛈️' },
+  85: { description: 'Slight snow showers', icon: '🌨️' },
+  86: { description: 'Heavy snow showers', icon: '❄️' },
+  95: { description: 'Thunderstorm', icon: '⛈️' },
+  96: { description: 'Thunderstorm with slight hail', icon: '⛈️' },
+  99: { description: 'Thunderstorm with heavy hail', icon: '⛈️' },
 };
 
 export async function fetchWeatherData(location: LocationData): Promise<WeatherData> {
@@ -108,8 +108,14 @@ export function getWeatherIcon(weatherCode: number): string {
   return WEATHER_CODES[weatherCode]?.icon || 'sunny';
 }
 
-export function formatTemperature(temp: number, unit: string = '°C'): string {
-  return `${Math.round(temp)}${unit}`;
+export function celsiusToFahrenheit(celsius: number): number {
+  return (celsius * 9) / 5 + 32;
+}
+
+export function formatTemperature(temp: number, unit: string = '°C', convertToFahrenheit: boolean = false): string {
+  const temperature = convertToFahrenheit ? celsiusToFahrenheit(temp) : temp;
+  const displayUnit = convertToFahrenheit ? '°F' : unit;
+  return `${Math.round(temperature)}${displayUnit}`;
 }
 
 export function formatPrecipitation(precipitation: number, unit: string = 'mm'): string {

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useState } from 'react';
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import Box from '@cloudscape-design/components/box';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { DashboardContent } from './components/dashboard-content';
+
+// Help panel content for the weather dashboard
+const WeatherHelpContent = () => (
+  <Box>
+    <Box variant="h3">Weather Dashboard</Box>
+    <Box variant="p">This dashboard displays real-time weather information and forecasts using the Open-Meteo API.</Box>
+    <Box variant="h4">Features:</Box>
+    <ul>
+      <li>Current weather conditions</li>
+      <li>24-hour hourly forecast</li>
+      <li>7-day daily forecast</li>
+      <li>Multiple location support</li>
+    </ul>
+    <Box variant="h4">Data Source:</Box>
+    <Box variant="p">
+      Weather data is provided by Open-Meteo, a free and open-source weather API that offers accurate and
+      high-resolution weather forecasts globally. No API key is required for this demo.
+    </Box>
+    <Box variant="h4">Location Selection:</Box>
+    <Box variant="p">
+      Choose from predefined locations or the default location (Berlin, Germany) to view weather data for different
+      cities around the world.
+    </Box>
+  </Box>
+);
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherHelpContent />);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        content={<DashboardContent />}
+        breadcrumbs={
+          <Breadcrumbs
+            items={[
+              { text: 'Home', href: '/' },
+              { text: 'Weather Dashboard', href: '/weather-dashboard' },
+            ]}
+          />
+        }
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+        navigationHide={true}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -32,15 +32,7 @@ export function CurrentWeather({ data, location }: CurrentWeatherProps) {
   };
 
   const getDayNightBadge = (isDay: number) => {
-    return isDay === 1 ? (
-      <Badge color="blue">
-        <Icon name="sun" /> Day
-      </Badge>
-    ) : (
-      <Badge color="grey">
-        <Icon name="moon" /> Night
-      </Badge>
-    );
+    return isDay === 1 ? <Badge color="blue">☀️ Day</Badge> : <Badge color="grey">🌙 Night</Badge>;
   };
 
   return (

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -1,0 +1,109 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Badge from '@cloudscape-design/components/badge';
+import Icon from '@cloudscape-design/components/icon';
+import { WeatherData, LocationData } from '../types';
+import {
+  getWeatherDescription,
+  formatTemperature,
+  formatWindSpeed,
+  formatWindDirection,
+  formatHumidity,
+  formatPressure,
+} from '../api';
+
+interface CurrentWeatherProps {
+  data: WeatherData;
+  location: LocationData;
+}
+
+export function CurrentWeather({ data, location }: CurrentWeatherProps) {
+  const { current, current_units } = data;
+
+  const formatDateTime = (dateTimeString: string) => {
+    return new Date(dateTimeString).toLocaleString();
+  };
+
+  const getDayNightBadge = (isDay: number) => {
+    return isDay === 1 ? (
+      <Badge color="blue">
+        <Icon name="sun" /> Day
+      </Badge>
+    ) : (
+      <Badge color="grey">
+        <Icon name="moon" /> Night
+      </Badge>
+    );
+  };
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={`Current weather conditions for ${location.city}, ${location.country}`}
+          info={getDayNightBadge(current.is_day)}
+        >
+          Current Weather
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <Box textAlign="center">
+          <SpaceBetween size="xs">
+            <Box fontSize="display-l" fontWeight="bold">
+              {formatTemperature(current.temperature_2m, current_units.temperature_2m)}
+            </Box>
+            <Box variant="h3" color="text-body-secondary">
+              {getWeatherDescription(current.weather_code)}
+            </Box>
+            <Box variant="small" color="text-body-secondary">
+              Feels like {formatTemperature(current.apparent_temperature, current_units.apparent_temperature)}
+            </Box>
+          </SpaceBetween>
+        </Box>
+
+        <KeyValuePairs
+          columns={3}
+          items={[
+            {
+              label: 'Humidity',
+              value: formatHumidity(current.relative_humidity_2m),
+            },
+            {
+              label: 'Wind',
+              value: `${formatWindSpeed(current.wind_speed_10m, current_units.wind_speed_10m)} ${formatWindDirection(current.wind_direction_10m)}`,
+            },
+            {
+              label: 'Pressure',
+              value: formatPressure(current.pressure_msl, current_units.pressure_msl),
+            },
+            {
+              label: 'Cloud Cover',
+              value: `${current.cloud_cover}%`,
+            },
+            {
+              label: 'Precipitation',
+              value: current.precipitation > 0 ? `${current.precipitation}${current_units.precipitation}` : 'None',
+            },
+            {
+              label: 'Wind Gusts',
+              value: formatWindSpeed(current.wind_gusts_10m, current_units.wind_gusts_10m),
+            },
+          ]}
+        />
+
+        <Box variant="small" color="text-body-secondary" textAlign="center">
+          Last updated: {formatDateTime(current.time)}
+        </Box>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -8,10 +8,10 @@ import Header from '@cloudscape-design/components/header';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Badge from '@cloudscape-design/components/badge';
-import Icon from '@cloudscape-design/components/icon';
 import { WeatherData, LocationData } from '../types';
 import {
   getWeatherDescription,
+  getWeatherIcon,
   formatTemperature,
   formatWindSpeed,
   formatWindDirection,
@@ -22,9 +22,10 @@ import {
 interface CurrentWeatherProps {
   data: WeatherData;
   location: LocationData;
+  useFahrenheit: boolean;
 }
 
-export function CurrentWeather({ data, location }: CurrentWeatherProps) {
+export function CurrentWeather({ data, location, useFahrenheit }: CurrentWeatherProps) {
   const { current, current_units } = data;
 
   const formatDateTime = (dateTimeString: string) => {
@@ -51,13 +52,15 @@ export function CurrentWeather({ data, location }: CurrentWeatherProps) {
         <Box textAlign="center">
           <SpaceBetween size="xs">
             <Box fontSize="display-l" fontWeight="bold">
-              {formatTemperature(current.temperature_2m, current_units.temperature_2m)}
+              {formatTemperature(current.temperature_2m, current_units.temperature_2m, useFahrenheit)}
             </Box>
+            <Box fontSize="display-l">{getWeatherIcon(current.weather_code)}</Box>
             <Box variant="h3" color="text-body-secondary">
               {getWeatherDescription(current.weather_code)}
             </Box>
             <Box variant="small" color="text-body-secondary">
-              Feels like {formatTemperature(current.apparent_temperature, current_units.apparent_temperature)}
+              Feels like{' '}
+              {formatTemperature(current.apparent_temperature, current_units.apparent_temperature, useFahrenheit)}
             </Box>
           </SpaceBetween>
         </Box>

--- a/src/pages/weather-dashboard/components/daily-forecast.module.scss
+++ b/src/pages/weather-dashboard/components/daily-forecast.module.scss
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.forecast-scroll-container {
+  display: flex;
+  overflow-x: auto;
+  gap: 16px;
+  padding-bottom: 8px;
+  min-height: 280px;
+  scroll-behavior: smooth;
+
+  // Custom scrollbar styling
+  &::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f1f3f4;
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: #a8a8a8;
+  }
+}
+
+.forecast-card {
+  min-width: 200px;
+  max-width: 200px;
+  border: 1px solid #e9ebed;
+  border-radius: 8px;
+  padding: 16px;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+  }
+}
+
+// Dark theme support
+@media (prefers-color-scheme: dark) {
+  .forecast-card {
+    background-color: #232f3e;
+    border-color: #414d5c;
+
+    &:hover {
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+    }
+  }
+
+  .forecast-scroll-container {
+    &::-webkit-scrollbar-track {
+      background: #414d5c;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #688092;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background: #879db0;
+    }
+  }
+}

--- a/src/pages/weather-dashboard/components/daily-forecast.tsx
+++ b/src/pages/weather-dashboard/components/daily-forecast.tsx
@@ -4,18 +4,18 @@
 import React from 'react';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
-import Table from '@cloudscape-design/components/table';
 import Box from '@cloudscape-design/components/box';
 import Badge from '@cloudscape-design/components/badge';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { WeatherData, DailyForecast } from '../types';
-import { getWeatherDescription, formatTemperature, formatWindSpeed } from '../api';
+import { getWeatherDescription, getWeatherIcon, formatTemperature, formatWindSpeed } from '../api';
 
 interface DailyForecastProps {
   data: WeatherData;
+  useFahrenheit: boolean;
 }
 
-export function DailyForecastWidget({ data }: DailyForecastProps) {
+export function DailyForecastWidget({ data, useFahrenheit }: DailyForecastProps) {
   const { daily, daily_units } = data;
 
   // Transform data for the next 7 days
@@ -44,7 +44,7 @@ export function DailyForecastWidget({ data }: DailyForecastProps) {
       return 'Tomorrow';
     }
     return date.toLocaleDateString([], {
-      weekday: 'long',
+      weekday: 'short',
       month: 'short',
       day: 'numeric',
     });
@@ -60,7 +60,7 @@ export function DailyForecastWidget({ data }: DailyForecastProps) {
   const getPrecipitationInfo = (sum: number, probability: number) => {
     if (sum > 0) {
       return (
-        <SpaceBetween direction="horizontal" size="xs">
+        <SpaceBetween direction="vertical" size="xxs">
           <Badge color="blue">{sum.toFixed(1)}mm</Badge>
           <Box variant="small" color="text-body-secondary">
             {probability}%
@@ -82,69 +82,72 @@ export function DailyForecastWidget({ data }: DailyForecastProps) {
         </Header>
       }
     >
-      <Table
-        columnDefinitions={[
-          {
-            id: 'date',
-            header: 'Date',
-            cell: item => formatDate(item.date),
-            minWidth: 120,
-          },
-          {
-            id: 'weather',
-            header: 'Weather',
-            cell: item => getWeatherDescription(item.weatherCode),
-            minWidth: 140,
-          },
-          {
-            id: 'temperature',
-            header: 'Temperature',
-            cell: item => (
-              <SpaceBetween direction="horizontal" size="xs">
-                <Box fontWeight="bold">{formatTemperature(item.temperatureMax, daily_units.temperature_2m_max)}</Box>
-                <Box color="text-body-secondary">
-                  {formatTemperature(item.temperatureMin, daily_units.temperature_2m_min)}
+      <Box>
+        <div
+          style={{
+            display: 'flex',
+            overflowX: 'auto',
+            gap: '16px',
+            paddingBottom: '8px',
+            minHeight: '280px',
+          }}
+        >
+          {dailyForecasts.map((forecast, index) => (
+            <div
+              key={index}
+              style={{
+                minWidth: '200px',
+                maxWidth: '200px',
+                border: '1px solid #e9ebed',
+                borderRadius: '8px',
+                padding: '16px',
+                backgroundColor: '#ffffff',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                textAlign: 'center',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+              }}
+            >
+              <SpaceBetween size="s" direction="vertical" alignItems="center">
+                <Box variant="h4" fontWeight="bold">
+                  {formatDate(forecast.date)}
                 </Box>
+
+                <Box fontSize="display-l" textAlign="center">
+                  {getWeatherIcon(forecast.weatherCode)}
+                </Box>
+
+                <Box variant="small" color="text-body-secondary" textAlign="center">
+                  {getWeatherDescription(forecast.weatherCode)}
+                </Box>
+
+                <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+                  <Box fontWeight="bold" fontSize="heading-m">
+                    {formatTemperature(forecast.temperatureMax, daily_units.temperature_2m_max, useFahrenheit)}
+                  </Box>
+                  <Box color="text-body-secondary" fontSize="body-m">
+                    {formatTemperature(forecast.temperatureMin, daily_units.temperature_2m_min, useFahrenheit)}
+                  </Box>
+                </SpaceBetween>
+
+                <Box textAlign="center">
+                  {getPrecipitationInfo(forecast.precipitationSum, forecast.precipitationProbability)}
+                </Box>
+
+                <Box variant="small" color="text-body-secondary" textAlign="center">
+                  💨 {formatWindSpeed(forecast.windSpeed, daily_units.wind_speed_10m_max)}
+                </Box>
+
+                <SpaceBetween direction="vertical" size="xxs" alignItems="center">
+                  <Box variant="small">🌅 {formatTime(forecast.sunrise)}</Box>
+                  <Box variant="small">🌇 {formatTime(forecast.sunset)}</Box>
+                </SpaceBetween>
               </SpaceBetween>
-            ),
-            minWidth: 120,
-          },
-          {
-            id: 'precipitation',
-            header: 'Precipitation',
-            cell: item => getPrecipitationInfo(item.precipitationSum, item.precipitationProbability),
-            minWidth: 130,
-          },
-          {
-            id: 'wind',
-            header: 'Max Wind',
-            cell: item => formatWindSpeed(item.windSpeed, daily_units.wind_speed_10m_max),
-            minWidth: 100,
-          },
-          {
-            id: 'sun',
-            header: 'Sunrise / Sunset',
-            cell: item => (
-              <SpaceBetween direction="vertical" size="xxs">
-                <Box variant="small">🌅 {formatTime(item.sunrise)}</Box>
-                <Box variant="small">🌇 {formatTime(item.sunset)}</Box>
-              </SpaceBetween>
-            ),
-            minWidth: 140,
-          },
-        ]}
-        items={dailyForecasts}
-        loadingText="Loading forecast..."
-        sortingDisabled
-        empty={
-          <Box textAlign="center" color="inherit">
-            <Box variant="strong" textAlign="center" color="inherit">
-              No daily forecast data available
-            </Box>
-          </Box>
-        }
-        header={<Header>Next 7 days</Header>}
-      />
+            </div>
+          ))}
+        </div>
+      </Box>
     </Container>
   );
 }

--- a/src/pages/weather-dashboard/components/daily-forecast.tsx
+++ b/src/pages/weather-dashboard/components/daily-forecast.tsx
@@ -1,0 +1,150 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import { WeatherData, DailyForecast } from '../types';
+import { getWeatherDescription, formatTemperature, formatWindSpeed } from '../api';
+
+interface DailyForecastProps {
+  data: WeatherData;
+}
+
+export function DailyForecastWidget({ data }: DailyForecastProps) {
+  const { daily, daily_units } = data;
+
+  // Transform data for the next 7 days
+  const dailyForecasts: DailyForecast[] = daily.time.map((date, index) => ({
+    date,
+    weatherCode: daily.weather_code[index],
+    temperatureMax: daily.temperature_2m_max[index],
+    temperatureMin: daily.temperature_2m_min[index],
+    precipitationSum: daily.precipitation_sum[index],
+    precipitationProbability: daily.precipitation_probability_max[index],
+    windSpeed: daily.wind_speed_10m_max[index],
+    sunrise: daily.sunrise[index],
+    sunset: daily.sunset[index],
+  }));
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    }
+    if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    }
+    return date.toLocaleDateString([], {
+      weekday: 'long',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getPrecipitationInfo = (sum: number, probability: number) => {
+    if (sum > 0) {
+      return (
+        <SpaceBetween direction="horizontal" size="xs">
+          <Badge color="blue">{sum.toFixed(1)}mm</Badge>
+          <Box variant="small" color="text-body-secondary">
+            {probability}%
+          </Box>
+        </SpaceBetween>
+      );
+    }
+    if (probability > 30) {
+      return <Badge color="grey">{probability}%</Badge>;
+    }
+    return <Box color="text-body-secondary">—</Box>;
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="7-day weather forecast">
+          Weekly Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'date',
+            header: 'Date',
+            cell: item => formatDate(item.date),
+            minWidth: 120,
+          },
+          {
+            id: 'weather',
+            header: 'Weather',
+            cell: item => getWeatherDescription(item.weatherCode),
+            minWidth: 140,
+          },
+          {
+            id: 'temperature',
+            header: 'Temperature',
+            cell: item => (
+              <SpaceBetween direction="horizontal" size="xs">
+                <Box fontWeight="bold">{formatTemperature(item.temperatureMax, daily_units.temperature_2m_max)}</Box>
+                <Box color="text-body-secondary">
+                  {formatTemperature(item.temperatureMin, daily_units.temperature_2m_min)}
+                </Box>
+              </SpaceBetween>
+            ),
+            minWidth: 120,
+          },
+          {
+            id: 'precipitation',
+            header: 'Precipitation',
+            cell: item => getPrecipitationInfo(item.precipitationSum, item.precipitationProbability),
+            minWidth: 130,
+          },
+          {
+            id: 'wind',
+            header: 'Max Wind',
+            cell: item => formatWindSpeed(item.windSpeed, daily_units.wind_speed_10m_max),
+            minWidth: 100,
+          },
+          {
+            id: 'sun',
+            header: 'Sunrise / Sunset',
+            cell: item => (
+              <SpaceBetween direction="vertical" size="xxs">
+                <Box variant="small">🌅 {formatTime(item.sunrise)}</Box>
+                <Box variant="small">🌇 {formatTime(item.sunset)}</Box>
+              </SpaceBetween>
+            ),
+            minWidth: 140,
+          },
+        ]}
+        items={dailyForecasts}
+        loadingText="Loading forecast..."
+        sortingDisabled
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="strong" textAlign="center" color="inherit">
+              No daily forecast data available
+            </Box>
+          </Box>
+        }
+        header={<Header>Next 7 days</Header>}
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/daily-forecast.tsx
+++ b/src/pages/weather-dashboard/components/daily-forecast.tsx
@@ -9,6 +9,7 @@ import Badge from '@cloudscape-design/components/badge';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { WeatherData, DailyForecast } from '../types';
 import { getWeatherDescription, getWeatherIcon, formatTemperature, formatWindSpeed } from '../api';
+import styles from './daily-forecast.module.scss';
 
 interface DailyForecastProps {
   data: WeatherData;
@@ -83,32 +84,9 @@ export function DailyForecastWidget({ data, useFahrenheit }: DailyForecastProps)
       }
     >
       <Box>
-        <div
-          style={{
-            display: 'flex',
-            overflowX: 'auto',
-            gap: '16px',
-            paddingBottom: '8px',
-            minHeight: '280px',
-          }}
-        >
+        <div className={styles['forecast-scroll-container']}>
           {dailyForecasts.map((forecast, index) => (
-            <div
-              key={index}
-              style={{
-                minWidth: '200px',
-                maxWidth: '200px',
-                border: '1px solid #e9ebed',
-                borderRadius: '8px',
-                padding: '16px',
-                backgroundColor: '#ffffff',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                textAlign: 'center',
-                boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-              }}
-            >
+            <div key={index} className={styles['forecast-card']}>
               <SpaceBetween size="s" direction="vertical" alignItems="center">
                 <Box variant="h4" fontWeight="bold">
                   {formatDate(forecast.date)}

--- a/src/pages/weather-dashboard/components/dashboard-content.tsx
+++ b/src/pages/weather-dashboard/components/dashboard-content.tsx
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useState, useEffect, useCallback } from 'react';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Box from '@cloudscape-design/components/box';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Alert from '@cloudscape-design/components/alert';
+
+import { WeatherData, LocationData } from '../types';
+import { fetchWeatherData, DEFAULT_LOCATIONS } from '../api';
+import { DashboardHeader } from './dashboard-header';
+import { LocationSelector } from './location-selector';
+import { CurrentWeather } from './current-weather';
+import { HourlyForecastWidget } from './hourly-forecast';
+import { DailyForecastWidget } from './daily-forecast';
+
+export function DashboardContent() {
+  const [selectedLocation, setSelectedLocation] = useState<LocationData>(DEFAULT_LOCATIONS[0]);
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadWeatherData = useCallback(async (location: LocationData) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchWeatherData(location);
+      setWeatherData(data);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load weather data';
+      setError(errorMessage);
+      console.error('Weather data fetch error:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleLocationChange = useCallback(
+    (location: LocationData) => {
+      setSelectedLocation(location);
+      loadWeatherData(location);
+    },
+    [loadWeatherData],
+  );
+
+  const handleRefresh = useCallback(() => {
+    loadWeatherData(selectedLocation);
+  }, [loadWeatherData, selectedLocation]);
+
+  // Load initial data
+  useEffect(() => {
+    loadWeatherData(selectedLocation);
+  }, [loadWeatherData, selectedLocation]);
+
+  const renderContent = () => {
+    if (loading && !weatherData) {
+      return (
+        <Box textAlign="center" padding="xxl">
+          <StatusIndicator type="loading">Loading weather data...</StatusIndicator>
+        </Box>
+      );
+    }
+
+    if (error) {
+      return (
+        <Alert
+          statusIconAriaLabel="Error"
+          type="error"
+          header="Failed to load weather data"
+          action={<button onClick={handleRefresh}>Retry</button>}
+        >
+          {error}
+        </Alert>
+      );
+    }
+
+    if (!weatherData) {
+      return (
+        <Box textAlign="center" padding="xxl">
+          <StatusIndicator type="stopped">No weather data available</StatusIndicator>
+        </Box>
+      );
+    }
+
+    return (
+      <SpaceBetween size="l">
+        <Grid gridDefinition={[{ colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 3 } }]}>
+          <LocationSelector
+            locations={DEFAULT_LOCATIONS}
+            selectedLocation={selectedLocation}
+            onLocationChange={handleLocationChange}
+            loading={loading}
+          />
+        </Grid>
+
+        <CurrentWeather data={weatherData} location={selectedLocation} />
+
+        <HourlyForecastWidget data={weatherData} />
+
+        <DailyForecastWidget data={weatherData} />
+      </SpaceBetween>
+    );
+  };
+
+  return (
+    <SpaceBetween size="l">
+      <DashboardHeader location={selectedLocation} onRefresh={handleRefresh} loading={loading} />
+
+      {renderContent()}
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/dashboard-content.tsx
+++ b/src/pages/weather-dashboard/components/dashboard-content.tsx
@@ -19,13 +19,31 @@ import { HourlyForecastWidget } from './hourly-forecast';
 import { TemperatureChart } from './temperature-chart';
 import { PrecipitationChart } from './precipitation-chart';
 
+/**
+ * Main dashboard content component that manages weather data state and renders all weather widgets.
+ * Handles location selection, temperature unit preferences, data loading, error states, and UI layout.
+ *
+ * @returns {JSX.Element} The complete weather dashboard content with all widgets and controls
+ */
 export function DashboardContent() {
+  /** Currently selected location for weather data */
   const [selectedLocation, setSelectedLocation] = useState<LocationData>(DEFAULT_LOCATIONS[0]);
+  /** Weather data fetched from the API, null when not loaded */
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  /** Loading state indicator for API requests */
   const [loading, setLoading] = useState(false);
+  /** Error message from failed API requests, null when no error */
   const [error, setError] = useState<string | null>(null);
+  /** Temperature unit preference - true for Fahrenheit, false for Celsius */
   const [useFahrenheit, setUseFahrenheit] = useState(false);
 
+  /**
+   * Loads weather data for a specific location from the Open-Meteo API.
+   * Manages loading states and error handling during the fetch process.
+   *
+   * @param {LocationData} location - The location object containing latitude, longitude, and display info
+   * @returns {Promise<void>} Promise that resolves when data loading is complete
+   */
   const loadWeatherData = useCallback(async (location: LocationData) => {
     setLoading(true);
     setError(null);
@@ -42,6 +60,12 @@ export function DashboardContent() {
     }
   }, []);
 
+  /**
+   * Handles location change events from the location selector component.
+   * Updates the selected location state and triggers a new data fetch.
+   *
+   * @param {LocationData} location - The newly selected location
+   */
   const handleLocationChange = useCallback(
     (location: LocationData) => {
       setSelectedLocation(location);
@@ -50,15 +74,25 @@ export function DashboardContent() {
     [loadWeatherData],
   );
 
+  /**
+   * Handles refresh button clicks to reload weather data for the current location.
+   * Useful for getting the latest weather information.
+   */
   const handleRefresh = useCallback(() => {
     loadWeatherData(selectedLocation);
   }, [loadWeatherData, selectedLocation]);
 
-  // Load initial data
+  // Load initial data when component mounts or selected location changes
   useEffect(() => {
     loadWeatherData(selectedLocation);
   }, [loadWeatherData, selectedLocation]);
 
+  /**
+   * Renders the main dashboard content based on current state.
+   * Shows loading indicators, error messages, or the complete weather dashboard.
+   *
+   * @returns {JSX.Element} Content to display in the main dashboard area
+   */
   const renderContent = () => {
     if (loading && !weatherData) {
       return (
@@ -91,6 +125,7 @@ export function DashboardContent() {
 
     return (
       <SpaceBetween size="l">
+        {/* Control panel with location selector and temperature unit toggle */}
         <Grid
           gridDefinition={[
             { colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 3 } },
@@ -106,10 +141,13 @@ export function DashboardContent() {
           <TemperatureToggle useFahrenheit={useFahrenheit} onChange={setUseFahrenheit} />
         </Grid>
 
+        {/* Current weather conditions display */}
         <CurrentWeather data={weatherData} location={selectedLocation} useFahrenheit={useFahrenheit} />
 
+        {/* 7-day forecast with horizontal scroll */}
         <DailyForecastWidget data={weatherData} useFahrenheit={useFahrenheit} />
 
+        {/* Charts section with temperature trends and precipitation */}
         <Grid
           gridDefinition={[
             { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
@@ -120,6 +158,7 @@ export function DashboardContent() {
           <PrecipitationChart data={weatherData} />
         </Grid>
 
+        {/* 24-hour detailed forecast table */}
         <HourlyForecastWidget data={weatherData} useFahrenheit={useFahrenheit} />
       </SpaceBetween>
     );
@@ -127,8 +166,10 @@ export function DashboardContent() {
 
   return (
     <SpaceBetween size="l">
+      {/* Dashboard header with location info and refresh controls */}
       <DashboardHeader location={selectedLocation} onRefresh={handleRefresh} loading={loading} />
 
+      {/* Main dashboard content area */}
       {renderContent()}
     </SpaceBetween>
   );

--- a/src/pages/weather-dashboard/components/dashboard-content.tsx
+++ b/src/pages/weather-dashboard/components/dashboard-content.tsx
@@ -12,15 +12,19 @@ import { WeatherData, LocationData } from '../types';
 import { fetchWeatherData, DEFAULT_LOCATIONS } from '../api';
 import { DashboardHeader } from './dashboard-header';
 import { LocationSelector } from './location-selector';
+import { TemperatureToggle } from './temperature-toggle';
 import { CurrentWeather } from './current-weather';
-import { HourlyForecastWidget } from './hourly-forecast';
 import { DailyForecastWidget } from './daily-forecast';
+import { HourlyForecastWidget } from './hourly-forecast';
+import { TemperatureChart } from './temperature-chart';
+import { PrecipitationChart } from './precipitation-chart';
 
 export function DashboardContent() {
   const [selectedLocation, setSelectedLocation] = useState<LocationData>(DEFAULT_LOCATIONS[0]);
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [useFahrenheit, setUseFahrenheit] = useState(false);
 
   const loadWeatherData = useCallback(async (location: LocationData) => {
     setLoading(true);
@@ -87,20 +91,36 @@ export function DashboardContent() {
 
     return (
       <SpaceBetween size="l">
-        <Grid gridDefinition={[{ colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 3 } }]}>
+        <Grid
+          gridDefinition={[
+            { colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 3 } },
+            { colspan: { default: 12, xs: 12, s: 6, m: 4, l: 4, xl: 3 } },
+          ]}
+        >
           <LocationSelector
             locations={DEFAULT_LOCATIONS}
             selectedLocation={selectedLocation}
             onLocationChange={handleLocationChange}
             loading={loading}
           />
+          <TemperatureToggle useFahrenheit={useFahrenheit} onChange={setUseFahrenheit} />
         </Grid>
 
-        <CurrentWeather data={weatherData} location={selectedLocation} />
+        <CurrentWeather data={weatherData} location={selectedLocation} useFahrenheit={useFahrenheit} />
 
-        <HourlyForecastWidget data={weatherData} />
+        <DailyForecastWidget data={weatherData} useFahrenheit={useFahrenheit} />
 
-        <DailyForecastWidget data={weatherData} />
+        <Grid
+          gridDefinition={[
+            { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
+            { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } },
+          ]}
+        >
+          <TemperatureChart data={weatherData} useFahrenheit={useFahrenheit} />
+          <PrecipitationChart data={weatherData} />
+        </Grid>
+
+        <HourlyForecastWidget data={weatherData} useFahrenheit={useFahrenheit} />
       </SpaceBetween>
     );
   };

--- a/src/pages/weather-dashboard/components/dashboard-header.tsx
+++ b/src/pages/weather-dashboard/components/dashboard-header.tsx
@@ -31,7 +31,7 @@ export function DashboardHeader({ location, onRefresh, loading = false }: Dashbo
       }
       info={
         <SpaceBetween direction="horizontal" size="xs">
-          <Icon name="location" />
+          📍
           <span>
             {location.latitude.toFixed(4)}, {location.longitude.toFixed(4)}
           </span>

--- a/src/pages/weather-dashboard/components/dashboard-header.tsx
+++ b/src/pages/weather-dashboard/components/dashboard-header.tsx
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Header from '@cloudscape-design/components/header';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Icon from '@cloudscape-design/components/icon';
+import { LocationData } from '../types';
+
+interface DashboardHeaderProps {
+  location: LocationData;
+  onRefresh: () => void;
+  loading?: boolean;
+}
+
+export function DashboardHeader({ location, onRefresh, loading = false }: DashboardHeaderProps) {
+  return (
+    <Header
+      variant="h1"
+      description={`Real-time weather data and forecasts powered by Open-Meteo API for ${location.city}, ${location.country}`}
+      actions={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button iconName="refresh" loading={loading} onClick={onRefresh}>
+            Refresh Data
+          </Button>
+          <Button variant="primary" iconName="external" iconAlign="right" href="https://open-meteo.com" target="_blank">
+            Open-Meteo API
+          </Button>
+        </SpaceBetween>
+      }
+      info={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Icon name="location" />
+          <span>
+            {location.latitude.toFixed(4)}, {location.longitude.toFixed(4)}
+          </span>
+        </SpaceBetween>
+      }
+    >
+      Weather Dashboard
+    </Header>
+  );
+}

--- a/src/pages/weather-dashboard/components/hourly-forecast.tsx
+++ b/src/pages/weather-dashboard/components/hourly-forecast.tsx
@@ -7,14 +7,23 @@ import Header from '@cloudscape-design/components/header';
 import Table from '@cloudscape-design/components/table';
 import Box from '@cloudscape-design/components/box';
 import Badge from '@cloudscape-design/components/badge';
+import SpaceBetween from '@cloudscape-design/components/space-between';
 import { WeatherData, HourlyForecast } from '../types';
-import { getWeatherDescription, formatTemperature, formatWindSpeed, formatWindDirection, formatHumidity } from '../api';
+import {
+  getWeatherDescription,
+  getWeatherIcon,
+  formatTemperature,
+  formatWindSpeed,
+  formatWindDirection,
+  formatHumidity,
+} from '../api';
 
 interface HourlyForecastProps {
   data: WeatherData;
+  useFahrenheit: boolean;
 }
 
-export function HourlyForecastWidget({ data }: HourlyForecastProps) {
+export function HourlyForecastWidget({ data, useFahrenheit }: HourlyForecastProps) {
   const { hourly, hourly_units } = data;
 
   // Transform data for the next 24 hours
@@ -66,14 +75,19 @@ export function HourlyForecastWidget({ data }: HourlyForecastProps) {
           {
             id: 'temperature',
             header: 'Temperature',
-            cell: item => formatTemperature(item.temperature, hourly_units.temperature_2m),
+            cell: item => formatTemperature(item.temperature, hourly_units.temperature_2m, useFahrenheit),
             minWidth: 100,
           },
           {
             id: 'weather',
             header: 'Weather',
-            cell: item => getWeatherDescription(item.weatherCode),
-            minWidth: 140,
+            cell: item => (
+              <SpaceBetween direction="horizontal" size="s" alignItems="center">
+                <Box fontSize="body-l">{getWeatherIcon(item.weatherCode)}</Box>
+                <Box>{getWeatherDescription(item.weatherCode)}</Box>
+              </SpaceBetween>
+            ),
+            minWidth: 180,
           },
           {
             id: 'precipitation',

--- a/src/pages/weather-dashboard/components/hourly-forecast.tsx
+++ b/src/pages/weather-dashboard/components/hourly-forecast.tsx
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import { WeatherData, HourlyForecast } from '../types';
+import { getWeatherDescription, formatTemperature, formatWindSpeed, formatWindDirection, formatHumidity } from '../api';
+
+interface HourlyForecastProps {
+  data: WeatherData;
+}
+
+export function HourlyForecastWidget({ data }: HourlyForecastProps) {
+  const { hourly, hourly_units } = data;
+
+  // Transform data for the next 24 hours
+  const hourlyForecasts: HourlyForecast[] = hourly.time.slice(0, 24).map((time, index) => ({
+    time,
+    temperature: hourly.temperature_2m[index],
+    precipitation: hourly.precipitation[index],
+    precipitationProbability: hourly.precipitation_probability[index],
+    weatherCode: hourly.weather_code[index],
+    windSpeed: hourly.wind_speed_10m[index],
+    windDirection: hourly.wind_direction_10m[index],
+    cloudCover: hourly.cloud_cover[index],
+    humidity: hourly.relative_humidity_2m[index],
+  }));
+
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getPrecipitationBadge = (precipitation: number, probability: number) => {
+    if (precipitation > 0) {
+      return <Badge color="blue">{precipitation.toFixed(1)}mm</Badge>;
+    }
+    if (probability > 50) {
+      return <Badge color="grey">{probability}%</Badge>;
+    }
+    return <Box color="text-body-secondary">—</Box>;
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Hourly forecast for the next 24 hours">
+          24-Hour Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'time',
+            header: 'Time',
+            cell: item => formatTime(item.time),
+            minWidth: 80,
+          },
+          {
+            id: 'temperature',
+            header: 'Temperature',
+            cell: item => formatTemperature(item.temperature, hourly_units.temperature_2m),
+            minWidth: 100,
+          },
+          {
+            id: 'weather',
+            header: 'Weather',
+            cell: item => getWeatherDescription(item.weatherCode),
+            minWidth: 140,
+          },
+          {
+            id: 'precipitation',
+            header: 'Precipitation',
+            cell: item => getPrecipitationBadge(item.precipitation, item.precipitationProbability),
+            minWidth: 110,
+          },
+          {
+            id: 'wind',
+            header: 'Wind',
+            cell: item =>
+              `${formatWindSpeed(item.windSpeed, hourly_units.wind_speed_10m)} ${formatWindDirection(item.windDirection)}`,
+            minWidth: 100,
+          },
+          {
+            id: 'humidity',
+            header: 'Humidity',
+            cell: item => formatHumidity(item.humidity),
+            minWidth: 90,
+          },
+          {
+            id: 'cloudCover',
+            header: 'Cloud Cover',
+            cell: item => `${item.cloudCover}%`,
+            minWidth: 100,
+          },
+        ]}
+        items={hourlyForecasts}
+        loadingText="Loading forecast..."
+        sortingDisabled
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="strong" textAlign="center" color="inherit">
+              No hourly data available
+            </Box>
+          </Box>
+        }
+        header={<Header>Next 24 hours</Header>}
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/location-selector.tsx
+++ b/src/pages/weather-dashboard/components/location-selector.tsx
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Select from '@cloudscape-design/components/select';
+import FormField from '@cloudscape-design/components/form-field';
+import { LocationData } from '../types';
+
+interface LocationSelectorProps {
+  locations: LocationData[];
+  selectedLocation: LocationData;
+  onLocationChange: (location: LocationData) => void;
+  loading?: boolean;
+}
+
+export function LocationSelector({
+  locations,
+  selectedLocation,
+  onLocationChange,
+  loading = false,
+}: LocationSelectorProps) {
+  const options = locations.map(location => ({
+    label: `${location.city}, ${location.country}`,
+    value: `${location.latitude},${location.longitude}`,
+    description: `Lat: ${location.latitude.toFixed(4)}, Lng: ${location.longitude.toFixed(4)}`,
+    tags: [location.country],
+  }));
+
+  const selectedOption = options.find(
+    option => option.value === `${selectedLocation.latitude},${selectedLocation.longitude}`,
+  );
+
+  return (
+    <FormField label="Location" description="Select a location to view weather data">
+      <Select
+        selectedOption={selectedOption || null}
+        onChange={({ detail }) => {
+          if (detail.selectedOption) {
+            const [lat, lng] = detail.selectedOption.value.split(',').map(Number);
+            const location = locations.find(loc => loc.latitude === lat && loc.longitude === lng);
+            if (location) {
+              onLocationChange(location);
+            }
+          }
+        }}
+        options={options}
+        loadingText="Loading locations..."
+        statusType={loading ? 'loading' : 'finished'}
+        placeholder="Choose a location"
+        expandToViewport={true}
+        filteringType="auto"
+      />
+    </FormField>
+  );
+}

--- a/src/pages/weather-dashboard/components/location-selector.tsx
+++ b/src/pages/weather-dashboard/components/location-selector.tsx
@@ -35,7 +35,7 @@ export function LocationSelector({
       <Select
         selectedOption={selectedOption || null}
         onChange={({ detail }) => {
-          if (detail.selectedOption) {
+          if (detail.selectedOption?.value) {
             const [lat, lng] = detail.selectedOption.value.split(',').map(Number);
             const location = locations.find(loc => loc.latitude === lat && loc.longitude === lng);
             if (location) {

--- a/src/pages/weather-dashboard/components/precipitation-chart.tsx
+++ b/src/pages/weather-dashboard/components/precipitation-chart.tsx
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
+import { WeatherData } from '../types';
+
+interface PrecipitationChartProps {
+  data: WeatherData;
+}
+
+export function PrecipitationChart({ data }: PrecipitationChartProps) {
+  const { hourly, hourly_units } = data;
+
+  // Get next 12 hours of precipitation data
+  const precipitationData = hourly.time.slice(0, 12).map((time, index) => ({
+    x: new Date(time).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    }),
+    y: hourly.precipitation[index] || 0,
+  }));
+
+  const chartData = [
+    {
+      title: 'Precipitation',
+      type: 'bar' as const,
+      data: precipitationData,
+      color: '#0073bb',
+    },
+  ];
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="12-hour precipitation forecast">
+          Precipitation Forecast
+        </Header>
+      }
+    >
+      <BarChart
+        series={chartData}
+        xTitle="Time"
+        yTitle={`Precipitation (${hourly_units.precipitation})`}
+        height={300}
+        i18nStrings={{
+          filterLabel: 'Filter',
+          filterPlaceholder: 'Filter data',
+          filterSelectedAriaLabel: 'selected',
+          detailPopoverDismissAriaLabel: 'Dismiss',
+          legendAriaLabel: 'Legend',
+          chartAriaRoleDescription: 'bar chart',
+          yTickFormatter: value => `${value.toFixed(1)}${hourly_units.precipitation}`,
+        }}
+        ariaLabel="Precipitation forecast for next 12 hours"
+        ariaDescription="Bar chart showing expected precipitation amounts over the next 12 hours"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="strong" textAlign="center" color="inherit">
+              No precipitation data available
+            </Box>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/temperature-chart.tsx
+++ b/src/pages/weather-dashboard/components/temperature-chart.tsx
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import LineChart from '@cloudscape-design/components/line-chart';
+import Box from '@cloudscape-design/components/box';
+import { WeatherData } from '../types';
+import { formatTemperature, celsiusToFahrenheit } from '../api';
+
+interface TemperatureChartProps {
+  data: WeatherData;
+  useFahrenheit: boolean;
+}
+
+export function TemperatureChart({ data, useFahrenheit }: TemperatureChartProps) {
+  const { hourly, hourly_units } = data;
+
+  // Get next 24 hours of temperature data
+  const temperatureData = hourly.time.slice(0, 24).map((time, index) => {
+    const temperature = hourly.temperature_2m[index];
+    const convertedTemp = useFahrenheit ? celsiusToFahrenheit(temperature) : temperature;
+
+    return {
+      x: new Date(time).getTime(),
+      y: convertedTemp,
+    };
+  });
+
+  const chartData = [
+    {
+      title: 'Temperature',
+      type: 'line' as const,
+      data: temperatureData,
+      color: '#0073bb',
+    },
+  ];
+
+  const unit = useFahrenheit ? '°F' : hourly_units.temperature_2m;
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="24-hour temperature trend">
+          Temperature Trend
+        </Header>
+      }
+    >
+      <LineChart
+        series={chartData}
+        xDomain={[temperatureData[0]?.x, temperatureData[temperatureData.length - 1]?.x]}
+        yDomain={[Math.min(...temperatureData.map(d => d.y)) - 2, Math.max(...temperatureData.map(d => d.y)) + 2]}
+        xTitle="Time"
+        yTitle={`Temperature (${unit})`}
+        height={300}
+        xScaleType="time"
+        i18nStrings={{
+          filterLabel: 'Filter',
+          filterPlaceholder: 'Filter data',
+          filterSelectedAriaLabel: 'selected',
+          detailPopoverDismissAriaLabel: 'Dismiss',
+          legendAriaLabel: 'Legend',
+          chartAriaRoleDescription: 'line chart',
+          xTickFormatter: value =>
+            new Date(value).toLocaleTimeString([], {
+              hour: '2-digit',
+              minute: '2-digit',
+            }),
+          yTickFormatter: value => `${Math.round(value)}${unit}`,
+        }}
+        ariaLabel="Temperature trend over 24 hours"
+        ariaDescription="Line chart showing temperature changes over the next 24 hours"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="strong" textAlign="center" color="inherit">
+              No temperature data available
+            </Box>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/temperature-toggle.tsx
+++ b/src/pages/weather-dashboard/components/temperature-toggle.tsx
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Toggle from '@cloudscape-design/components/toggle';
+import FormField from '@cloudscape-design/components/form-field';
+
+interface TemperatureToggleProps {
+  useFahrenheit: boolean;
+  onChange: (useFahrenheit: boolean) => void;
+}
+
+export function TemperatureToggle({ useFahrenheit, onChange }: TemperatureToggleProps) {
+  return (
+    <FormField label="Temperature Unit" description="Switch between Celsius and Fahrenheit">
+      <Toggle checked={useFahrenheit} onChange={({ detail }) => onChange(detail.checked)}>
+        {useFahrenheit ? '°F (Fahrenheit)' : '°C (Celsius)'}
+      </Toggle>
+    </FormField>
+  );
+}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/types.ts
+++ b/src/pages/weather-dashboard/types.ts
@@ -120,3 +120,14 @@ export interface DailyForecast {
   sunrise: string;
   sunset: string;
 }
+
+export interface TemperatureUnit {
+  celsius: boolean;
+  fahrenheit: boolean;
+}
+
+export interface ChartDataPoint {
+  time: string;
+  value: number;
+  label: string;
+}

--- a/src/pages/weather-dashboard/types.ts
+++ b/src/pages/weather-dashboard/types.ts
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface WeatherData {
+  current: {
+    time: string;
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    apparent_temperature: number;
+    is_day: number;
+    precipitation: number;
+    weather_code: number;
+    cloud_cover: number;
+    pressure_msl: number;
+    surface_pressure: number;
+    wind_speed_10m: number;
+    wind_direction_10m: number;
+    wind_gusts_10m: number;
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    relative_humidity_2m: number[];
+    precipitation_probability: number[];
+    precipitation: number[];
+    weather_code: number[];
+    cloud_cover: number[];
+    wind_speed_10m: number[];
+    wind_direction_10m: number[];
+  };
+  daily: {
+    time: string[];
+    weather_code: number[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    apparent_temperature_max: number[];
+    apparent_temperature_min: number[];
+    sunrise: string[];
+    sunset: string[];
+    precipitation_sum: number[];
+    precipitation_probability_max: number[];
+    wind_speed_10m_max: number[];
+    wind_gusts_10m_max: number[];
+  };
+  current_units: {
+    time: string;
+    temperature_2m: string;
+    relative_humidity_2m: string;
+    apparent_temperature: string;
+    precipitation: string;
+    weather_code: string;
+    cloud_cover: string;
+    pressure_msl: string;
+    surface_pressure: string;
+    wind_speed_10m: string;
+    wind_direction_10m: string;
+    wind_gusts_10m: string;
+  };
+  hourly_units: {
+    time: string;
+    temperature_2m: string;
+    relative_humidity_2m: string;
+    precipitation_probability: string;
+    precipitation: string;
+    weather_code: string;
+    cloud_cover: string;
+    wind_speed_10m: string;
+    wind_direction_10m: string;
+  };
+  daily_units: {
+    time: string;
+    weather_code: string;
+    temperature_2m_max: string;
+    temperature_2m_min: string;
+    apparent_temperature_max: string;
+    apparent_temperature_min: string;
+    sunrise: string;
+    sunset: string;
+    precipitation_sum: string;
+    precipitation_probability_max: string;
+    wind_speed_10m_max: string;
+    wind_gusts_10m_max: string;
+  };
+}
+
+export interface LocationData {
+  latitude: number;
+  longitude: number;
+  city: string;
+  country: string;
+}
+
+export interface WeatherCodeMapping {
+  [key: number]: {
+    description: string;
+    icon: string;
+  };
+}
+
+export interface HourlyForecast {
+  time: string;
+  temperature: number;
+  precipitation: number;
+  precipitationProbability: number;
+  weatherCode: number;
+  windSpeed: number;
+  windDirection: number;
+  cloudCover: number;
+  humidity: number;
+}
+
+export interface DailyForecast {
+  date: string;
+  weatherCode: number;
+  temperatureMax: number;
+  temperatureMin: number;
+  precipitationSum: number;
+  precipitationProbability: number;
+  windSpeed: number;
+  sunrise: string;
+  sunset: string;
+}


### PR DESCRIPTION
Adds a comprehensive weather dashboard feature with the following components:

- New weather dashboard page at `/weather-dashboard` route
- Integration with Open-Meteo API for real-time weather data
- Current weather conditions display with temperature, humidity, wind, and pressure
- 7-day daily forecast with temperature ranges and precipitation
- 24-hour hourly forecast table
- Interactive temperature and precipitation charts
- Location selector supporting multiple cities (Berlin, New York, Tokyo, London, San Francisco)
- Temperature unit toggle (Celsius/Fahrenheit)
- Responsive design with grid layout
- Error handling and loading states
- TypeScript interfaces for weather data structures

Files added:
- `src/pages/weather-dashboard/` - Complete dashboard implementation
- `src/pages/weather-dashboard/api.ts` - Weather API integration
- `src/pages/weather-dashboard/app.tsx` - Main application component
- `src/pages/weather-dashboard/components/` - Weather widgets and charts
- `src/pages/weather-dashboard/types.ts` - TypeScript definitions

Files modified:
- `src/pages/index.tsx` - Added weather dashboard to demos list

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 26`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/echo-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->