### PR TITLE
Add weather dashboard demo with Open-Meteo API

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather dashboard powered by Open-Meteo API.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { Content } from './components/content';
+import { WeatherHeader, WeatherMainInfo } from './components/header';
+import { WeatherSideNavigation } from './components/side-navigation';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherMainInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <WeatherHeader actions={<Button variant="primary">Add Location</Button>} />
+            <Content />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+        navigation={<WeatherSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -11,18 +11,31 @@ import { CustomAppLayout } from '../commons/common-components';
 import { Content } from './components/content';
 import { WeatherHeader, WeatherMainInfo } from './components/header';
 import { WeatherSideNavigation } from './components/side-navigation';
+import { WeatherProvider, useWeatherContext } from './context/weather-context';
+import { WeatherLocation } from './widgets/interfaces';
 
 import '@cloudscape-design/global-styles/dark-mode-utils.css';
 
-export function App() {
+function WeatherApp() {
   const [toolsOpen, setToolsOpen] = useState(false);
   const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherMainInfo />);
   const appLayout = useRef<AppLayoutProps.Ref>(null);
+  const { currentLocation, setCurrentLocation, searchLoading, setSearchLoading } = useWeatherContext();
 
   const handleToolsContentChange = (content: React.ReactNode) => {
     setToolsOpen(true);
     setToolsContent(content);
     appLayout.current?.focusToolsClose();
+  };
+
+  const handleLocationSelect = async (location: WeatherLocation) => {
+    setSearchLoading(true);
+    try {
+      setCurrentLocation(location);
+      // The widgets will automatically update due to the context change
+    } finally {
+      setSearchLoading(false);
+    }
   };
 
   return (
@@ -31,11 +44,22 @@ export function App() {
         ref={appLayout}
         content={
           <SpaceBetween size="m">
-            <WeatherHeader actions={<Button variant="primary">Add Location</Button>} />
+            <WeatherHeader
+              actions={<Button variant="primary">Add Location</Button>}
+              onLocationSelect={handleLocationSelect}
+              searchLoading={searchLoading}
+            />
             <Content />
           </SpaceBetween>
         }
-        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+        breadcrumbs={
+          <Breadcrumbs
+            items={[
+              { text: 'Weather Dashboard', href: '#/' },
+              { text: currentLocation.name, href: '#/' },
+            ]}
+          />
+        }
         navigation={<WeatherSideNavigation />}
         tools={toolsContent}
         toolsOpen={toolsOpen}
@@ -43,5 +67,13 @@ export function App() {
         notifications={<Notifications />}
       />
     </HelpPanelProvider>
+  );
+}
+
+export function App() {
+  return (
+    <WeatherProvider>
+      <WeatherApp />
+    </WeatherProvider>
   );
 }

--- a/src/pages/weather-dashboard/components/content.tsx
+++ b/src/pages/weather-dashboard/components/content.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Grid from '@cloudscape-design/components/grid';
+
+import {
+  BaseWeatherWidget,
+  currentWeather,
+  forecast,
+  temperature,
+  precipitation,
+  wind,
+  humidity,
+  weatherAlerts,
+  locations,
+} from '../widgets';
+
+export function Content() {
+  return (
+    <Grid
+      gridDefinition={[
+        { colspan: { l: 6, m: 6, default: 12 } },
+        { colspan: { l: 6, m: 6, default: 12 } },
+        { colspan: { l: 8, m: 8, default: 12 } },
+        { colspan: { l: 4, m: 4, default: 12 } },
+        { colspan: { l: 4, m: 4, default: 12 } },
+        { colspan: { l: 4, m: 4, default: 12 } },
+        { colspan: { l: 4, m: 4, default: 12 } },
+        { colspan: { l: 12, m: 12, default: 12 } },
+      ]}
+    >
+      {[currentWeather, forecast, temperature, weatherAlerts, precipitation, wind, humidity, locations].map(
+        (widget, index) => (
+          <BaseWeatherWidget key={index} config={widget.data} />
+        ),
+      )}
+    </Grid>
+  );
+}

--- a/src/pages/weather-dashboard/components/header.tsx
+++ b/src/pages/weather-dashboard/components/header.tsx
@@ -8,15 +8,31 @@ import HelpPanel from '@cloudscape-design/components/help-panel';
 import Link from '@cloudscape-design/components/link';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 
+import { LocationSearch } from './location-search';
+import { WeatherLocation } from '../widgets/interfaces';
+
 interface WeatherHeaderProps {
   actions?: React.ReactNode;
+  onLocationSelect?: (location: WeatherLocation) => void;
+  searchLoading?: boolean;
 }
 
-export function WeatherHeader({ actions }: WeatherHeaderProps) {
+export function WeatherHeader({ actions, onLocationSelect, searchLoading = false }: WeatherHeaderProps) {
   return (
-    <Header variant="h1" actions={actions} description="Real-time weather data powered by Open-Meteo API">
-      Weather Dashboard
-    </Header>
+    <SpaceBetween size="l">
+      <Header variant="h1" actions={actions} description="Real-time weather data powered by Open-Meteo API">
+        Weather Dashboard
+      </Header>
+
+      {onLocationSelect && (
+        <Box>
+          <Box variant="h3" margin={{ bottom: 's' }}>
+            Search for any location
+          </Box>
+          <LocationSearch onLocationSelect={onLocationSelect} loading={searchLoading} />
+        </Box>
+      )}
+    </SpaceBetween>
   );
 }
 

--- a/src/pages/weather-dashboard/components/header.tsx
+++ b/src/pages/weather-dashboard/components/header.tsx
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import HelpPanel from '@cloudscape-design/components/help-panel';
+import Link from '@cloudscape-design/components/link';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+interface WeatherHeaderProps {
+  actions?: React.ReactNode;
+}
+
+export function WeatherHeader({ actions }: WeatherHeaderProps) {
+  return (
+    <Header variant="h1" actions={actions} description="Real-time weather data powered by Open-Meteo API">
+      Weather Dashboard
+    </Header>
+  );
+}
+
+export function WeatherMainInfo() {
+  return (
+    <HelpPanel
+      header={<h2>Weather Dashboard</h2>}
+      footer={
+        <>
+          <h3>
+            Learn more{' '}
+            <span role="img" aria-label="Icon external Link">
+              ↗
+            </span>
+          </h3>
+          <ul>
+            <li>
+              <Link external href="https://open-meteo.com/">
+                Open-Meteo API
+              </Link>
+            </li>
+            <li>
+              <Link external href="https://cloudscape.design/">
+                Cloudscape Design System
+              </Link>
+            </li>
+          </ul>
+        </>
+      }
+    >
+      <Box variant="p">
+        This weather dashboard displays real-time and forecast weather data using the Open-Meteo API. The dashboard
+        shows current conditions, temperature trends, precipitation forecasts, and more for multiple locations.
+      </Box>
+      <SpaceBetween size="l">
+        <Box variant="h3">Features</Box>
+        <ul>
+          <li>Current weather conditions with live updates</li>
+          <li>7-day weather forecast with detailed charts</li>
+          <li>Temperature and precipitation trends</li>
+          <li>Wind speed and humidity monitoring</li>
+          <li>Weather alerts and warnings</li>
+          <li>Multiple location tracking</li>
+        </ul>
+      </SpaceBetween>
+    </HelpPanel>
+  );
+}

--- a/src/pages/weather-dashboard/components/location-search.tsx
+++ b/src/pages/weather-dashboard/components/location-search.tsx
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useCallback } from 'react';
+
+import Autosuggest from '@cloudscape-design/components/autosuggest';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import FormField from '@cloudscape-design/components/form-field';
+
+import { WeatherAPI } from '../services/weather-api';
+import { WeatherLocation } from '../widgets/interfaces';
+
+interface LocationSearchProps {
+  onLocationSelect: (location: WeatherLocation) => void;
+  loading?: boolean;
+}
+
+export function LocationSearch({ onLocationSelect, loading = false }: LocationSearchProps) {
+  const [searchValue, setSearchValue] = useState('');
+  const [searchOptions, setSearchOptions] = useState<{ value: string; location: WeatherLocation }[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [selectedLocation, setSelectedLocation] = useState<WeatherLocation | null>(null);
+
+  const handleSearch = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setSearchOptions([]);
+      return;
+    }
+
+    setSearchLoading(true);
+    try {
+      const locations = await WeatherAPI.searchLocations(query);
+      const options = locations.map(location => ({
+        value: location.name,
+        location,
+      }));
+      setSearchOptions(options);
+    } catch (error) {
+      console.error('Search failed:', error);
+      setSearchOptions([]);
+    } finally {
+      setSearchLoading(false);
+    }
+  }, []);
+
+  const handleSelect = (option: { value: string; location: WeatherLocation }) => {
+    setSelectedLocation(option.location);
+    setSearchValue(option.value);
+    setSearchOptions([]);
+  };
+
+  const handleViewWeather = () => {
+    if (selectedLocation) {
+      onLocationSelect(selectedLocation);
+      setSearchValue('');
+      setSelectedLocation(null);
+    }
+  };
+
+  return (
+    <SpaceBetween size="s" direction="horizontal">
+      <FormField stretch>
+        <Autosuggest
+          onChange={({ detail }) => {
+            setSearchValue(detail.value);
+            handleSearch(detail.value);
+          }}
+          onSelect={({ detail }) => {
+            const option = searchOptions.find(opt => opt.value === detail.value);
+            if (option) {
+              handleSelect(option);
+            }
+          }}
+          value={searchValue}
+          options={searchOptions.map(opt => ({ value: opt.value }))}
+          loadingText="Searching locations..."
+          statusType={searchLoading ? 'loading' : 'finished'}
+          placeholder="Search for a city (e.g., San Francisco, London, Tokyo)"
+          ariaLabel="Location search"
+          enteredTextLabel={value => `Search for "${value}"`}
+          empty="No locations found"
+          finishedText={
+            searchOptions.length > 0
+              ? `${searchOptions.length} location${searchOptions.length === 1 ? '' : 's'} found`
+              : undefined
+          }
+        />
+      </FormField>
+      <Button variant="primary" onClick={handleViewWeather} disabled={!selectedLocation || loading} loading={loading}>
+        View Weather
+      </Button>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/side-navigation.tsx
+++ b/src/pages/weather-dashboard/components/side-navigation.tsx
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation from '@cloudscape-design/components/side-navigation';
+
+import { SideNavigationProps } from '@cloudscape-design/components/side-navigation';
+
+export function WeatherSideNavigation() {
+  const handleFollow: SideNavigationProps['onFollow'] = event => {
+    // This is just a demo, so we prevent navigation
+    event.preventDefault();
+  };
+
+  return (
+    <SideNavigation
+      activeHref="#/"
+      header={{ href: '#/', text: 'Weather Service' }}
+      onFollow={handleFollow}
+      items={[
+        { type: 'link', text: 'Dashboard', href: '#/' },
+        { type: 'divider' },
+        {
+          type: 'section',
+          text: 'Locations',
+          items: [
+            { type: 'link', text: 'New York', href: '#/locations/new-york' },
+            { type: 'link', text: 'London', href: '#/locations/london' },
+            { type: 'link', text: 'Tokyo', href: '#/locations/tokyo' },
+            { type: 'link', text: 'Sydney', href: '#/locations/sydney' },
+          ],
+        },
+        { type: 'divider' },
+        {
+          type: 'section',
+          text: 'Weather Data',
+          items: [
+            { type: 'link', text: 'Current Conditions', href: '#/current' },
+            { type: 'link', text: 'Forecasts', href: '#/forecasts' },
+            { type: 'link', text: 'Historical Data', href: '#/historical' },
+            { type: 'link', text: 'Alerts', href: '#/alerts' },
+          ],
+        },
+        { type: 'divider' },
+        {
+          type: 'section',
+          text: 'Settings',
+          items: [
+            { type: 'link', text: 'Preferences', href: '#/preferences' },
+            { type: 'link', text: 'API Configuration', href: '#/api-config' },
+          ],
+        },
+      ]}
+    />
+  );
+}

--- a/src/pages/weather-dashboard/context/weather-context.tsx
+++ b/src/pages/weather-dashboard/context/weather-context.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+import { WeatherLocation } from '../widgets/interfaces';
+import { DEFAULT_LOCATIONS } from '../services/weather-api';
+
+interface WeatherContextType {
+  currentLocation: WeatherLocation;
+  setCurrentLocation: (location: WeatherLocation) => void;
+  searchLoading: boolean;
+  setSearchLoading: (loading: boolean) => void;
+}
+
+const WeatherContext = createContext<WeatherContextType | undefined>(undefined);
+
+export function useWeatherContext() {
+  const context = useContext(WeatherContext);
+  if (!context) {
+    throw new Error('useWeatherContext must be used within a WeatherProvider');
+  }
+  return context;
+}
+
+interface WeatherProviderProps {
+  children: ReactNode;
+}
+
+export function WeatherProvider({ children }: WeatherProviderProps) {
+  const [currentLocation, setCurrentLocation] = useState<WeatherLocation>(DEFAULT_LOCATIONS[0]); // Default to New York
+  const [searchLoading, setSearchLoading] = useState(false);
+
+  return (
+    <WeatherContext.Provider
+      value={{
+        currentLocation,
+        setCurrentLocation,
+        searchLoading,
+        setSearchLoading,
+      }}
+    >
+      {children}
+    </WeatherContext.Provider>
+  );
+}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/services/weather-api.ts
+++ b/src/pages/weather-dashboard/services/weather-api.ts
@@ -1,0 +1,201 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { WeatherLocation, WeatherAPIResponse } from '../widgets/interfaces';
+
+export class WeatherAPI {
+  private static readonly BASE_URL = 'https://api.open-meteo.com/v1/forecast';
+
+  static async getCurrentWeather(location: WeatherLocation): Promise<WeatherAPIResponse> {
+    const params = new URLSearchParams({
+      latitude: location.latitude.toString(),
+      longitude: location.longitude.toString(),
+      current: [
+        'temperature_2m',
+        'relative_humidity_2m',
+        'apparent_temperature',
+        'is_day',
+        'precipitation',
+        'weather_code',
+        'cloud_cover',
+        'pressure_msl',
+        'surface_pressure',
+        'wind_speed_10m',
+        'wind_direction_10m',
+        'wind_gusts_10m',
+      ].join(','),
+      hourly: [
+        'temperature_2m',
+        'relative_humidity_2m',
+        'precipitation_probability',
+        'precipitation',
+        'weather_code',
+        'pressure_msl',
+        'cloud_cover',
+        'visibility',
+        'wind_speed_10m',
+        'wind_direction_10m',
+        'uv_index',
+      ].join(','),
+      daily: [
+        'weather_code',
+        'temperature_2m_max',
+        'temperature_2m_min',
+        'apparent_temperature_max',
+        'apparent_temperature_min',
+        'sunrise',
+        'sunset',
+        'uv_index_max',
+        'precipitation_sum',
+        'rain_sum',
+        'showers_sum',
+        'snowfall_sum',
+        'precipitation_hours',
+        'precipitation_probability_max',
+        'wind_speed_10m_max',
+        'wind_gusts_10m_max',
+        'wind_direction_10m_dominant',
+      ].join(','),
+      timezone: location.timezone,
+      forecast_days: '7',
+    });
+
+    const response = await fetch(`${this.BASE_URL}?${params}`);
+
+    if (!response.ok) {
+      throw new Error(`Weather API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    return {
+      current: {
+        temperature: data.current.temperature_2m,
+        humidity: data.current.relative_humidity_2m,
+        windSpeed: data.current.wind_speed_10m,
+        windDirection: data.current.wind_direction_10m,
+        pressure: data.current.pressure_msl,
+        visibility: data.hourly.visibility?.[0] || 10000,
+        uvIndex: data.hourly.uv_index?.[0] || 0,
+        weatherCode: data.current.weather_code,
+        isDay: data.current.is_day === 1,
+        time: data.current.time,
+      },
+      hourly: {
+        time: data.hourly.time.slice(0, 24), // Next 24 hours
+        temperature: data.hourly.temperature_2m.slice(0, 24),
+        humidity: data.hourly.relative_humidity_2m.slice(0, 24),
+        precipitation: data.hourly.precipitation.slice(0, 24),
+        windSpeed: data.hourly.wind_speed_10m.slice(0, 24),
+        weatherCode: data.hourly.weather_code.slice(0, 24),
+      },
+      daily: {
+        time: data.daily.time,
+        temperatureMax: data.daily.temperature_2m_max,
+        temperatureMin: data.daily.temperature_2m_min,
+        precipitation: data.daily.precipitation_sum,
+        windSpeedMax: data.daily.wind_speed_10m_max,
+        weatherCode: data.daily.weather_code,
+      },
+    };
+  }
+
+  static getWeatherDescription(weatherCode: number): string {
+    const weatherCodes: Record<number, string> = {
+      0: 'Clear sky',
+      1: 'Mainly clear',
+      2: 'Partly cloudy',
+      3: 'Overcast',
+      45: 'Fog',
+      48: 'Depositing rime fog',
+      51: 'Light drizzle',
+      53: 'Moderate drizzle',
+      55: 'Dense drizzle',
+      56: 'Light freezing drizzle',
+      57: 'Dense freezing drizzle',
+      61: 'Slight rain',
+      63: 'Moderate rain',
+      65: 'Heavy rain',
+      66: 'Light freezing rain',
+      67: 'Heavy freezing rain',
+      71: 'Slight snow fall',
+      73: 'Moderate snow fall',
+      75: 'Heavy snow fall',
+      77: 'Snow grains',
+      80: 'Slight rain showers',
+      81: 'Moderate rain showers',
+      82: 'Violent rain showers',
+      85: 'Slight snow showers',
+      86: 'Heavy snow showers',
+      95: 'Thunderstorm',
+      96: 'Thunderstorm with slight hail',
+      99: 'Thunderstorm with heavy hail',
+    };
+
+    return weatherCodes[weatherCode] || 'Unknown';
+  }
+
+  static getWeatherIcon(weatherCode: number, isDay: boolean = true): string {
+    // Map weather codes to appropriate icons
+    const iconMap: Record<number, { day: string; night: string }> = {
+      0: { day: '☀️', night: '🌙' },
+      1: { day: '🌤️', night: '🌙' },
+      2: { day: '⛅', night: '☁️' },
+      3: { day: '☁️', night: '☁️' },
+      45: { day: '🌫️', night: '🌫️' },
+      48: { day: '🌫️', night: '🌫️' },
+      51: { day: '🌦️', night: '🌧️' },
+      53: { day: '🌦️', night: '🌧️' },
+      55: { day: '🌦️', night: '🌧️' },
+      56: { day: '🌨️', night: '🌨️' },
+      57: { day: '🌨️', night: '🌨️' },
+      61: { day: '🌧️', night: '🌧️' },
+      63: { day: '🌧️', night: '🌧️' },
+      65: { day: '🌧️', night: '🌧️' },
+      66: { day: '🌨️', night: '🌨️' },
+      67: { day: '🌨️', night: '🌨️' },
+      71: { day: '🌨️', night: '🌨️' },
+      73: { day: '❄️', night: '❄️' },
+      75: { day: '❄️', night: '❄️' },
+      77: { day: '🌨️', night: '🌨️' },
+      80: { day: '🌦️', night: '🌧️' },
+      81: { day: '🌧️', night: '🌧️' },
+      82: { day: '⛈️', night: '⛈️' },
+      85: { day: '🌨️', night: '🌨️' },
+      86: { day: '❄️', night: '❄️' },
+      95: { day: '⛈️', night: '⛈️' },
+      96: { day: '⛈️', night: '⛈️' },
+      99: { day: '⛈️', night: '⛈️' },
+    };
+
+    const icons = iconMap[weatherCode] || { day: '❓', night: '❓' };
+    return isDay ? icons.day : icons.night;
+  }
+}
+
+// Default locations for demo
+export const DEFAULT_LOCATIONS: WeatherLocation[] = [
+  {
+    name: 'New York',
+    latitude: 40.7128,
+    longitude: -74.006,
+    timezone: 'America/New_York',
+  },
+  {
+    name: 'London',
+    latitude: 51.5074,
+    longitude: -0.1278,
+    timezone: 'Europe/London',
+  },
+  {
+    name: 'Tokyo',
+    latitude: 35.6762,
+    longitude: 139.6503,
+    timezone: 'Asia/Tokyo',
+  },
+  {
+    name: 'Sydney',
+    latitude: -33.8688,
+    longitude: 151.2093,
+    timezone: 'Australia/Sydney',
+  },
+];

--- a/src/pages/weather-dashboard/widgets/base-weather-widget/index.tsx
+++ b/src/pages/weather-dashboard/widgets/base-weather-widget/index.tsx
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+
+import { WeatherDataType } from '../interfaces';
+
+import * as styles from './styles.module.scss';
+
+export function BaseWeatherWidget({ config }: { config: WeatherDataType }) {
+  const Wrapper = config.provider ?? React.Fragment;
+  return (
+    <div className={styles.weatherWidget} style={{ minHeight: config.staticMinHeight }}>
+      <Wrapper>
+        <Container
+          header={<config.header />}
+          fitHeight={true}
+          footer={config.footer && <config.footer />}
+          disableContentPaddings={config.disableContentPaddings}
+        >
+          <config.content />
+        </Container>
+      </Wrapper>
+    </div>
+  );
+}

--- a/src/pages/weather-dashboard/widgets/base-weather-widget/styles.module.scss
+++ b/src/pages/weather-dashboard/widgets/base-weather-widget/styles.module.scss
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.weatherWidget {
+  height: 100%;
+
+  :global(.awsui-container) {
+    height: 100%;
+  }
+
+  :global(.awsui-container-content) {
+    padding-bottom: 0;
+  }
+}

--- a/src/pages/weather-dashboard/widgets/current-weather/index.tsx
+++ b/src/pages/weather-dashboard/widgets/current-weather/index.tsx
@@ -8,13 +8,16 @@ import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 
-import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPI } from '../../services/weather-api';
 import { CurrentWeatherData } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
+import { useWeatherContext } from '../../context/weather-context';
 
 function CurrentWeatherHeader() {
+  const { currentLocation } = useWeatherContext();
+
   return (
-    <Header variant="h2" description="Live weather conditions for New York">
+    <Header variant="h2" description={`Live weather conditions for ${currentLocation.name}`}>
       Current Weather
     </Header>
   );
@@ -24,13 +27,14 @@ function CurrentWeatherWidget() {
   const [weatherData, setWeatherData] = useState<CurrentWeatherData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { currentLocation } = useWeatherContext();
 
   useEffect(() => {
     const fetchWeather = async () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]); // New York
+        const response = await WeatherAPI.getCurrentWeather(currentLocation);
         setWeatherData(response.current);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch weather data');
@@ -44,7 +48,7 @@ function CurrentWeatherWidget() {
     // Refresh every 5 minutes
     const interval = setInterval(fetchWeather, 5 * 60 * 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [currentLocation]);
 
   if (loading) {
     return (

--- a/src/pages/weather-dashboard/widgets/current-weather/index.tsx
+++ b/src/pages/weather-dashboard/widgets/current-weather/index.tsx
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { CurrentWeatherData } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function CurrentWeatherHeader() {
+  return (
+    <Header variant="h2" description="Live weather conditions for New York">
+      Current Weather
+    </Header>
+  );
+}
+
+function CurrentWeatherWidget() {
+  const [weatherData, setWeatherData] = useState<CurrentWeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchWeather = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]); // New York
+        setWeatherData(response.current);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch weather data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchWeather();
+
+    // Refresh every 5 minutes
+    const interval = setInterval(fetchWeather, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner size="large" />
+        <Box variant="p" margin={{ top: 's' }}>
+          Loading current weather...
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="error">{error}</StatusIndicator>
+      </Box>
+    );
+  }
+
+  if (!weatherData) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="warning">No weather data available</StatusIndicator>
+      </Box>
+    );
+  }
+
+  const weatherIcon = WeatherAPI.getWeatherIcon(weatherData.weatherCode, weatherData.isDay);
+  const weatherDescription = WeatherAPI.getWeatherDescription(weatherData.weatherCode);
+
+  return (
+    <Box>
+      <Box textAlign="center" margin={{ bottom: 'l' }}>
+        <Box fontSize="display-l" margin={{ bottom: 'xs' }}>
+          {weatherIcon}
+        </Box>
+        <Box fontSize="heading-xl" margin={{ bottom: 'xs' }}>
+          {Math.round(weatherData.temperature)}°C
+        </Box>
+        <Box variant="p" color="text-status-inactive">
+          {weatherDescription}
+        </Box>
+      </Box>
+
+      <KeyValuePairs
+        columns={2}
+        items={[
+          {
+            label: 'Humidity',
+            value: `${weatherData.humidity}%`,
+          },
+          {
+            label: 'Wind Speed',
+            value: `${Math.round(weatherData.windSpeed)} km/h`,
+          },
+          {
+            label: 'Pressure',
+            value: `${Math.round(weatherData.pressure)} hPa`,
+          },
+          {
+            label: 'UV Index',
+            value: weatherData.uvIndex.toString(),
+          },
+        ]}
+      />
+    </Box>
+  );
+}
+
+export const currentWeather: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 3, defaultColumnSpan: 2 },
+  data: {
+    icon: 'status-positive',
+    title: 'Current Weather',
+    description: 'Real-time weather conditions',
+    header: CurrentWeatherHeader,
+    content: CurrentWeatherWidget,
+    staticMinHeight: 250,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/forecast/index.tsx
+++ b/src/pages/weather-dashboard/widgets/forecast/index.tsx
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Cards from '@cloudscape-design/components/cards';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPIResponse } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function ForecastHeader() {
+  return (
+    <Header variant="h2" description="7-day weather forecast">
+      Weekly Forecast
+    </Header>
+  );
+}
+
+function ForecastWidget() {
+  const [forecastData, setForecastData] = useState<WeatherAPIResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchForecast = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]); // New York
+        setForecastData(response);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch forecast data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchForecast();
+
+    // Refresh every 30 minutes
+    const interval = setInterval(fetchForecast, 30 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner size="large" />
+        <Box variant="p" margin={{ top: 's' }}>
+          Loading forecast...
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="error">{error}</StatusIndicator>
+      </Box>
+    );
+  }
+
+  if (!forecastData) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="warning">No forecast data available</StatusIndicator>
+      </Box>
+    );
+  }
+
+  const dailyForecasts = forecastData.daily.time.map((date, index) => {
+    const dayName = new Date(date).toLocaleDateString('en-US', { weekday: 'short' });
+    const weatherIcon = WeatherAPI.getWeatherIcon(forecastData.daily.weatherCode[index], true);
+
+    return {
+      id: date,
+      day: dayName,
+      date: new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+      icon: weatherIcon,
+      maxTemp: Math.round(forecastData.daily.temperatureMax[index]),
+      minTemp: Math.round(forecastData.daily.temperatureMin[index]),
+      precipitation: Math.round(forecastData.daily.precipitation[index]),
+      windSpeed: Math.round(forecastData.daily.windSpeedMax[index]),
+    };
+  });
+
+  return (
+    <Cards
+      cardsPerRow={[
+        { cards: 1, minWidth: 0 },
+        { cards: 2, minWidth: 400 },
+        { cards: 3, minWidth: 600 },
+        { cards: 4, minWidth: 800 },
+      ]}
+      cardDefinition={{
+        header: item => (
+          <Box>
+            <Box variant="h3">{item.day}</Box>
+            <Box variant="small" color="text-status-inactive">
+              {item.date}
+            </Box>
+          </Box>
+        ),
+        sections: [
+          {
+            id: 'weather',
+            content: item => (
+              <Box textAlign="center">
+                <Box fontSize="heading-l" margin={{ bottom: 'xs' }}>
+                  {item.icon}
+                </Box>
+                <Box variant="p">
+                  <strong>{item.maxTemp}°</strong> / {item.minTemp}°
+                </Box>
+              </Box>
+            ),
+          },
+          {
+            id: 'details',
+            content: item => (
+              <Box variant="small">
+                <div>Rain: {item.precipitation}mm</div>
+                <div>Wind: {item.windSpeed} km/h</div>
+              </Box>
+            ),
+          },
+        ],
+      }}
+      items={dailyForecasts}
+      trackBy="id"
+      empty={
+        <Box textAlign="center" color="inherit">
+          <Box variant="p">No forecast data available</Box>
+        </Box>
+      }
+    />
+  );
+}
+
+export const forecast: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 3, defaultColumnSpan: 2 },
+  data: {
+    icon: 'calendar',
+    title: 'Weather Forecast',
+    description: '7-day weather outlook',
+    header: ForecastHeader,
+    content: ForecastWidget,
+    staticMinHeight: 300,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/forecast/index.tsx
+++ b/src/pages/weather-dashboard/widgets/forecast/index.tsx
@@ -6,11 +6,12 @@ import Box from '@cloudscape-design/components/box';
 import Header from '@cloudscape-design/components/header';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
-import Cards from '@cloudscape-design/components/cards';
+import Container from '@cloudscape-design/components/container';
 
-import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPI } from '../../services/weather-api';
 import { WeatherAPIResponse } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
+import { useWeatherContext } from '../../context/weather-context';
 
 function ForecastHeader() {
   return (
@@ -24,13 +25,14 @@ function ForecastWidget() {
   const [forecastData, setForecastData] = useState<WeatherAPIResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { currentLocation } = useWeatherContext();
 
   useEffect(() => {
     const fetchForecast = async () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]); // New York
+        const response = await WeatherAPI.getCurrentWeather(currentLocation);
         setForecastData(response);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch forecast data');
@@ -44,7 +46,7 @@ function ForecastWidget() {
     // Refresh every 30 minutes
     const interval = setInterval(fetchForecast, 30 * 60 * 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [currentLocation]);
 
   if (loading) {
     return (
@@ -90,55 +92,62 @@ function ForecastWidget() {
   });
 
   return (
-    <Cards
-      cardsPerRow={[
-        { cards: 1, minWidth: 0 },
-        { cards: 2, minWidth: 400 },
-        { cards: 3, minWidth: 600 },
-        { cards: 4, minWidth: 800 },
-      ]}
-      cardDefinition={{
-        header: item => (
-          <Box>
-            <Box variant="h3">{item.day}</Box>
-            <Box variant="small" color="text-status-inactive">
-              {item.date}
-            </Box>
-          </Box>
-        ),
-        sections: [
-          {
-            id: 'weather',
-            content: item => (
+    <Box>
+      <div
+        style={{
+          display: 'flex',
+          gap: '16px',
+          overflowX: 'auto',
+          paddingBottom: '16px',
+          scrollBehavior: 'smooth',
+        }}
+      >
+        {dailyForecasts.map(item => (
+          <Container
+            key={item.id}
+            header={
               <Box textAlign="center">
-                <Box fontSize="heading-l" margin={{ bottom: 'xs' }}>
-                  {item.icon}
+                <Box variant="h4" margin={{ bottom: 'xxs' }}>
+                  {item.day}
                 </Box>
-                <Box variant="p">
-                  <strong>{item.maxTemp}°</strong> / {item.minTemp}°
+                <Box variant="small" color="text-status-inactive">
+                  {item.date}
                 </Box>
               </Box>
-            ),
-          },
-          {
-            id: 'details',
-            content: item => (
+            }
+            style={{
+              minWidth: '140px',
+              flexShrink: 0,
+            }}
+          >
+            <Box textAlign="center">
+              <Box fontSize="heading-l" margin={{ bottom: 's' }}>
+                {item.icon}
+              </Box>
+              <Box variant="p" margin={{ bottom: 's' }}>
+                <Box variant="strong" fontSize="heading-m">
+                  {item.maxTemp}°
+                </Box>
+                <Box variant="span" color="text-status-inactive">
+                  {' '}
+                  / {item.minTemp}°
+                </Box>
+              </Box>
               <Box variant="small">
-                <div>Rain: {item.precipitation}mm</div>
-                <div>Wind: {item.windSpeed} km/h</div>
+                <div style={{ marginBottom: '4px' }}>💧 {item.precipitation}mm</div>
+                <div>💨 {item.windSpeed} km/h</div>
               </Box>
-            ),
-          },
-        ],
-      }}
-      items={dailyForecasts}
-      trackBy="id"
-      empty={
-        <Box textAlign="center" color="inherit">
+            </Box>
+          </Container>
+        ))}
+      </div>
+
+      {dailyForecasts.length === 0 && (
+        <Box textAlign="center" color="inherit" padding="l">
           <Box variant="p">No forecast data available</Box>
         </Box>
-      }
-    />
+      )}
+    </Box>
   );
 }
 

--- a/src/pages/weather-dashboard/widgets/humidity/humidity-meter.tsx
+++ b/src/pages/weather-dashboard/widgets/humidity/humidity-meter.tsx
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+
+interface HumidityMeterProps {
+  humidity: number;
+  color: string;
+}
+
+export function HumidityMeter({ humidity, color }: HumidityMeterProps) {
+  const meterWidth = 200;
+  const fillWidth = (humidity / 100) * meterWidth;
+
+  return (
+    <Box textAlign="center" margin={{ bottom: 'l' }}>
+      <div
+        style={{
+          width: `${meterWidth}px`,
+          height: '20px',
+          backgroundColor: '#f1f1f1',
+          borderRadius: '10px',
+          position: 'relative',
+          margin: '0 auto',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${fillWidth}px`,
+            height: '100%',
+            backgroundColor: color,
+            borderRadius: '10px',
+            transition: 'width 0.3s ease',
+          }}
+        />
+      </div>
+      <Box variant="small" margin={{ top: 'xs' }}>
+        Humidity Level
+      </Box>
+    </Box>
+  );
+}

--- a/src/pages/weather-dashboard/widgets/humidity/index.tsx
+++ b/src/pages/weather-dashboard/widgets/humidity/index.tsx
@@ -9,6 +9,18 @@ import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 
 import { WeatherAPI } from '../../services/weather-api';
+import { CurrentWeatherData } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+import { useWeatherContext } from '../../context/weather-context';
+import { HumidityMeter } from './humidity-meter';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherAPI } from '../../services/weather-api';
 import { useWeatherContext } from '../../context/weather-context';
 import { CurrentWeatherData } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
@@ -77,16 +89,12 @@ function HumidityWidget() {
   const getHumidityLevel = (humidity: number): { description: string; emoji: string; color: string } => {
     if (humidity < 30) return { description: 'Very dry', emoji: '🏜️', color: '#d91515' };
     if (humidity < 50) return { description: 'Dry', emoji: '🌵', color: '#ff9900' };
-    if (humidity < 70) return { description: 'Comfortable', emoji: '😌', color: '#1d8102' };
+    if (humidity < 70) return { description: 'Comfortable', emoji: '��', color: '#1d8102' };
     if (humidity < 80) return { description: 'Humid', emoji: '💧', color: '#0073bb' };
     return { description: 'Very humid', emoji: '🌊', color: '#232f3e' };
   };
 
   const humidityLevel = getHumidityLevel(weatherData.humidity);
-
-  // Create a simple humidity meter visualization
-  const meterWidth = 200;
-  const fillWidth = (weatherData.humidity / 100) * meterWidth;
 
   return (
     <Box>
@@ -102,32 +110,7 @@ function HumidityWidget() {
         </Box>
       </Box>
 
-      <Box textAlign="center" margin={{ bottom: 'l' }}>
-        <div
-          style={{
-            width: `${meterWidth}px`,
-            height: '20px',
-            backgroundColor: '#f1f1f1',
-            borderRadius: '10px',
-            position: 'relative',
-            margin: '0 auto',
-            overflow: 'hidden',
-          }}
-        >
-          <div
-            style={{
-              width: `${fillWidth}px`,
-              height: '100%',
-              backgroundColor: humidityLevel.color,
-              borderRadius: '10px',
-              transition: 'width 0.3s ease',
-            }}
-          />
-        </div>
-        <Box variant="small" margin={{ top: 'xs' }}>
-          Humidity Level
-        </Box>
-      </Box>
+      <HumidityMeter humidity={weatherData.humidity} color={humidityLevel.color} />
 
       <KeyValuePairs
         columns={2}

--- a/src/pages/weather-dashboard/widgets/humidity/index.tsx
+++ b/src/pages/weather-dashboard/widgets/humidity/index.tsx
@@ -1,0 +1,165 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { CurrentWeatherData } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function HumidityHeader() {
+  return (
+    <Header variant="h2" description="Atmospheric humidity levels">
+      Humidity
+    </Header>
+  );
+}
+
+function HumidityWidget() {
+  const [weatherData, setWeatherData] = useState<CurrentWeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+        setWeatherData(response.current);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch humidity data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
+    const interval = setInterval(fetchData, 15 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner size="large" />
+        <Box variant="p" margin={{ top: 's' }}>
+          Loading humidity data...
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="error">{error}</StatusIndicator>
+      </Box>
+    );
+  }
+
+  if (!weatherData) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="warning">No humidity data available</StatusIndicator>
+      </Box>
+    );
+  }
+
+  const getHumidityLevel = (humidity: number): { description: string; emoji: string; color: string } => {
+    if (humidity < 30) return { description: 'Very dry', emoji: '🏜️', color: '#d91515' };
+    if (humidity < 50) return { description: 'Dry', emoji: '🌵', color: '#ff9900' };
+    if (humidity < 70) return { description: 'Comfortable', emoji: '😌', color: '#1d8102' };
+    if (humidity < 80) return { description: 'Humid', emoji: '💧', color: '#0073bb' };
+    return { description: 'Very humid', emoji: '🌊', color: '#232f3e' };
+  };
+
+  const humidityLevel = getHumidityLevel(weatherData.humidity);
+
+  // Create a simple humidity meter visualization
+  const meterWidth = 200;
+  const fillWidth = (weatherData.humidity / 100) * meterWidth;
+
+  return (
+    <Box>
+      <Box textAlign="center" margin={{ bottom: 'l' }}>
+        <Box fontSize="display-l" margin={{ bottom: 'xs' }}>
+          {humidityLevel.emoji}
+        </Box>
+        <Box fontSize="heading-xl" margin={{ bottom: 'xs' }}>
+          {weatherData.humidity}%
+        </Box>
+        <Box variant="p" color="text-status-inactive">
+          {humidityLevel.description}
+        </Box>
+      </Box>
+
+      <Box textAlign="center" margin={{ bottom: 'l' }}>
+        <div
+          style={{
+            width: `${meterWidth}px`,
+            height: '20px',
+            backgroundColor: '#f1f1f1',
+            borderRadius: '10px',
+            position: 'relative',
+            margin: '0 auto',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width: `${fillWidth}px`,
+              height: '100%',
+              backgroundColor: humidityLevel.color,
+              borderRadius: '10px',
+              transition: 'width 0.3s ease',
+            }}
+          />
+        </div>
+        <Box variant="small" margin={{ top: 'xs' }}>
+          Humidity Level
+        </Box>
+      </Box>
+
+      <KeyValuePairs
+        columns={2}
+        items={[
+          {
+            label: 'Current level',
+            value: `${weatherData.humidity}%`,
+          },
+          {
+            label: 'Status',
+            value: humidityLevel.description,
+          },
+          {
+            label: 'Pressure',
+            value: `${Math.round(weatherData.pressure)} hPa`,
+          },
+          {
+            label: 'Comfort',
+            value: weatherData.humidity >= 40 && weatherData.humidity <= 60 ? 'Optimal' : 'Suboptimal',
+          },
+        ]}
+      />
+    </Box>
+  );
+}
+
+export const humidity: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 2, defaultColumnSpan: 2 },
+  data: {
+    icon: 'notification',
+    title: 'Humidity',
+    description: 'Atmospheric humidity monitoring',
+    header: HumidityHeader,
+    content: HumidityWidget,
+    staticMinHeight: 200,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/humidity/index.tsx
+++ b/src/pages/weather-dashboard/widgets/humidity/index.tsx
@@ -8,7 +8,8 @@ import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 
-import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPI } from '../../services/weather-api';
+import { useWeatherContext } from '../../context/weather-context';
 import { CurrentWeatherData } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
 
@@ -24,13 +25,14 @@ function HumidityWidget() {
   const [weatherData, setWeatherData] = useState<CurrentWeatherData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { currentLocation } = useWeatherContext();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+        const response = await WeatherAPI.getCurrentWeather(currentLocation);
         setWeatherData(response.current);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch humidity data');
@@ -43,7 +45,7 @@ function HumidityWidget() {
 
     const interval = setInterval(fetchData, 15 * 60 * 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [currentLocation]);
 
   if (loading) {
     return (

--- a/src/pages/weather-dashboard/widgets/index.ts
+++ b/src/pages/weather-dashboard/widgets/index.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+export { BaseWeatherWidget } from './base-weather-widget';
+export { currentWeather } from './current-weather';
+export { forecast } from './forecast';
+export { temperature } from './temperature';
+export { precipitation } from './precipitation';
+export { wind } from './wind';
+export { humidity } from './humidity';
+export { weatherAlerts } from './weather-alerts';
+export { locations } from './locations';

--- a/src/pages/weather-dashboard/widgets/interfaces.ts
+++ b/src/pages/weather-dashboard/widgets/interfaces.ts
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import { BoardProps } from '@cloudscape-design/board-components/board';
+
+export interface WeatherDataType {
+  icon: string;
+  title: string;
+  description: string;
+  disableContentPaddings?: boolean;
+  provider?: React.JSXElementConstructor<{ children: React.ReactElement }>;
+  header: React.JSXElementConstructor<Record<string, never>>;
+  content: React.JSXElementConstructor<Record<string, never>>;
+  footer?: React.JSXElementConstructor<Record<string, never>>;
+  staticMinHeight?: number;
+}
+
+export type WeatherWidgetItem = BoardProps.Item<WeatherDataType>;
+
+export type WeatherWidgetConfig = Pick<WeatherWidgetItem, 'definition' | 'data'>;
+
+export interface WeatherLocation {
+  name: string;
+  latitude: number;
+  longitude: number;
+  timezone: string;
+}
+
+export interface CurrentWeatherData {
+  temperature: number;
+  humidity: number;
+  windSpeed: number;
+  windDirection: number;
+  pressure: number;
+  visibility: number;
+  uvIndex: number;
+  weatherCode: number;
+  isDay: boolean;
+  time: string;
+}
+
+export interface ForecastData {
+  time: string[];
+  temperature: number[];
+  humidity: number[];
+  precipitation: number[];
+  windSpeed: number[];
+  weatherCode: number[];
+}
+
+export interface WeatherAPIResponse {
+  current: CurrentWeatherData;
+  hourly: ForecastData;
+  daily: {
+    time: string[];
+    temperatureMax: number[];
+    temperatureMin: number[];
+    precipitation: number[];
+    windSpeedMax: number[];
+    weatherCode: number[];
+  };
+}

--- a/src/pages/weather-dashboard/widgets/locations/index.tsx
+++ b/src/pages/weather-dashboard/widgets/locations/index.tsx
@@ -1,0 +1,194 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Badge from '@cloudscape-design/components/badge';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherLocation, CurrentWeatherData } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function LocationsHeader() {
+  return (
+    <Header variant="h2" description="Weather conditions across multiple locations">
+      Location Overview
+    </Header>
+  );
+}
+
+interface LocationWeatherData extends WeatherLocation {
+  weather?: CurrentWeatherData;
+  loading: boolean;
+  error?: string;
+}
+
+function LocationsWidget() {
+  const [locationData, setLocationData] = useState<LocationWeatherData[]>(
+    DEFAULT_LOCATIONS.map(location => ({ ...location, loading: true })),
+  );
+
+  useEffect(() => {
+    const fetchAllLocations = async () => {
+      const updatedData = await Promise.all(
+        DEFAULT_LOCATIONS.map(async location => {
+          try {
+            const response = await WeatherAPI.getCurrentWeather(location);
+            return {
+              ...location,
+              weather: response.current,
+              loading: false,
+            };
+          } catch (error) {
+            return {
+              ...location,
+              loading: false,
+              error: error instanceof Error ? error.message : 'Failed to fetch weather',
+            };
+          }
+        }),
+      );
+
+      setLocationData(updatedData);
+    };
+
+    fetchAllLocations();
+
+    // Refresh every 10 minutes
+    const interval = setInterval(fetchAllLocations, 10 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const getTemperatureColor = (temp: number): 'blue' | 'green' | 'red' => {
+    if (temp < 10) return 'blue';
+    if (temp < 25) return 'green';
+    return 'red';
+  };
+
+  return (
+    <Table
+      columnDefinitions={[
+        {
+          id: 'name',
+          header: 'Location',
+          cell: item => (
+            <Box>
+              <Box variant="strong">{item.name}</Box>
+              <Box variant="small" color="text-status-inactive">
+                {item.latitude.toFixed(2)}, {item.longitude.toFixed(2)}
+              </Box>
+            </Box>
+          ),
+          sortingField: 'name',
+        },
+        {
+          id: 'weather',
+          header: 'Conditions',
+          cell: item => {
+            if (item.loading) {
+              return <Spinner size="normal" />;
+            }
+
+            if (item.error) {
+              return <StatusIndicator type="error">Error</StatusIndicator>;
+            }
+
+            if (!item.weather) {
+              return <StatusIndicator type="warning">No data</StatusIndicator>;
+            }
+
+            const icon = WeatherAPI.getWeatherIcon(item.weather.weatherCode, item.weather.isDay);
+            const description = WeatherAPI.getWeatherDescription(item.weather.weatherCode);
+
+            return (
+              <Box>
+                <span style={{ fontSize: '20px', marginRight: '8px' }}>{icon}</span>
+                {description}
+              </Box>
+            );
+          },
+        },
+        {
+          id: 'temperature',
+          header: 'Temperature',
+          cell: item => {
+            if (item.loading || item.error || !item.weather) {
+              return '—';
+            }
+
+            return (
+              <Badge color={getTemperatureColor(item.weather.temperature)}>
+                {Math.round(item.weather.temperature)}°C
+              </Badge>
+            );
+          },
+        },
+        {
+          id: 'humidity',
+          header: 'Humidity',
+          cell: item => {
+            if (item.loading || item.error || !item.weather) {
+              return '—';
+            }
+
+            return `${item.weather.humidity}%`;
+          },
+        },
+        {
+          id: 'wind',
+          header: 'Wind',
+          cell: item => {
+            if (item.loading || item.error || !item.weather) {
+              return '—';
+            }
+
+            return `${Math.round(item.weather.windSpeed)} km/h`;
+          },
+        },
+        {
+          id: 'localTime',
+          header: 'Local Time',
+          cell: item => {
+            const now = new Date();
+            const localTime = new Date(now.toLocaleString('en-US', { timeZone: item.timezone }));
+
+            return (
+              <Box variant="small">
+                {localTime.toLocaleTimeString('en-US', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  timeZone: item.timezone,
+                })}
+              </Box>
+            );
+          },
+        },
+      ]}
+      items={locationData}
+      trackBy="name"
+      sortingDisabled
+      empty={
+        <Box textAlign="center" color="inherit">
+          <Box variant="p">No locations configured</Box>
+        </Box>
+      }
+      header={<Header counter={`(${locationData.length})`}>Monitored Locations</Header>}
+    />
+  );
+}
+
+export const locations: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 2, defaultColumnSpan: 6 },
+  data: {
+    icon: 'location',
+    title: 'Location Overview',
+    description: 'Weather summary for all monitored locations',
+    header: LocationsHeader,
+    content: LocationsWidget,
+    staticMinHeight: 300,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/precipitation/index.tsx
+++ b/src/pages/weather-dashboard/widgets/precipitation/index.tsx
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPIResponse } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function PrecipitationHeader() {
+  return (
+    <Header variant="h2" description="Rainfall and precipitation data">
+      Precipitation
+    </Header>
+  );
+}
+
+function PrecipitationWidget() {
+  const [weatherData, setWeatherData] = useState<WeatherAPIResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+        setWeatherData(response);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch precipitation data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
+    const interval = setInterval(fetchData, 30 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner size="large" />
+        <Box variant="p" margin={{ top: 's' }}>
+          Loading precipitation data...
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="error">{error}</StatusIndicator>
+      </Box>
+    );
+  }
+
+  if (!weatherData) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="warning">No precipitation data available</StatusIndicator>
+      </Box>
+    );
+  }
+
+  const hourlyPrecipitation = weatherData.hourly.precipitation.slice(0, 24);
+  const dailyPrecipitation = weatherData.daily.precipitation.slice(0, 7);
+
+  const totalToday = hourlyPrecipitation.reduce((sum, val) => sum + val, 0);
+  const totalWeek = dailyPrecipitation.reduce((sum, val) => sum + val, 0);
+  const maxHourly = Math.max(...hourlyPrecipitation);
+  const avgDaily = totalWeek / 7;
+
+  const rainIcon = totalToday > 5 ? '🌧️' : totalToday > 1 ? '🌦️' : '☀️';
+
+  return (
+    <Box>
+      <Box textAlign="center" margin={{ bottom: 'l' }}>
+        <Box fontSize="display-l" margin={{ bottom: 'xs' }}>
+          {rainIcon}
+        </Box>
+        <Box fontSize="heading-xl" margin={{ bottom: 'xs' }}>
+          {totalToday.toFixed(1)}mm
+        </Box>
+        <Box variant="p" color="text-status-inactive">
+          Today's rainfall
+        </Box>
+      </Box>
+
+      <KeyValuePairs
+        columns={2}
+        items={[
+          {
+            label: 'This week',
+            value: `${totalWeek.toFixed(1)}mm`,
+          },
+          {
+            label: 'Daily average',
+            value: `${avgDaily.toFixed(1)}mm`,
+          },
+          {
+            label: 'Peak hour',
+            value: `${maxHourly.toFixed(1)}mm`,
+          },
+          {
+            label: 'Status',
+            value: totalToday > 10 ? 'Heavy rain' : totalToday > 2 ? 'Light rain' : 'Dry',
+          },
+        ]}
+      />
+    </Box>
+  );
+}
+
+export const precipitation: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 2, defaultColumnSpan: 2 },
+  data: {
+    icon: 'notification',
+    title: 'Precipitation',
+    description: 'Rainfall and precipitation tracking',
+    header: PrecipitationHeader,
+    content: PrecipitationWidget,
+    staticMinHeight: 200,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/precipitation/index.tsx
+++ b/src/pages/weather-dashboard/widgets/precipitation/index.tsx
@@ -8,7 +8,8 @@ import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 
-import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPI } from '../../services/weather-api';
+import { useWeatherContext } from '../../context/weather-context';
 import { WeatherAPIResponse } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
 
@@ -24,13 +25,14 @@ function PrecipitationWidget() {
   const [weatherData, setWeatherData] = useState<WeatherAPIResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { currentLocation } = useWeatherContext();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+        const response = await WeatherAPI.getCurrentWeather(currentLocation);
         setWeatherData(response);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch precipitation data');
@@ -43,7 +45,7 @@ function PrecipitationWidget() {
 
     const interval = setInterval(fetchData, 30 * 60 * 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [currentLocation]);
 
   if (loading) {
     return (

--- a/src/pages/weather-dashboard/widgets/temperature/index.tsx
+++ b/src/pages/weather-dashboard/widgets/temperature/index.tsx
@@ -7,9 +7,10 @@ import Header from '@cloudscape-design/components/header';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 
-import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPI } from '../../services/weather-api';
 import { WeatherAPIResponse } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
+import { useWeatherContext } from '../../context/weather-context';
 
 function TemperatureHeader() {
   return (
@@ -23,13 +24,14 @@ function TemperatureWidget() {
   const [weatherData, setWeatherData] = useState<WeatherAPIResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { currentLocation } = useWeatherContext();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]); // New York
+        const response = await WeatherAPI.getCurrentWeather(currentLocation);
         setWeatherData(response);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch temperature data');
@@ -43,7 +45,7 @@ function TemperatureWidget() {
     // Refresh every 30 minutes
     const interval = setInterval(fetchData, 30 * 60 * 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [currentLocation]);
 
   if (loading) {
     return (

--- a/src/pages/weather-dashboard/widgets/temperature/index.tsx
+++ b/src/pages/weather-dashboard/widgets/temperature/index.tsx
@@ -1,0 +1,147 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPIResponse } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function TemperatureHeader() {
+  return (
+    <Header variant="h2" description="24-hour temperature trend">
+      Temperature Trend
+    </Header>
+  );
+}
+
+function TemperatureWidget() {
+  const [weatherData, setWeatherData] = useState<WeatherAPIResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]); // New York
+        setWeatherData(response);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch temperature data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
+    // Refresh every 30 minutes
+    const interval = setInterval(fetchData, 30 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner size="large" />
+        <Box variant="p" margin={{ top: 's' }}>
+          Loading temperature data...
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="error">{error}</StatusIndicator>
+      </Box>
+    );
+  }
+
+  if (!weatherData) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="warning">No temperature data available</StatusIndicator>
+      </Box>
+    );
+  }
+
+  const temperatures = weatherData.hourly.temperature;
+  const times = weatherData.hourly.time;
+
+  const maxTemp = Math.max(...temperatures);
+  const minTemp = Math.min(...temperatures);
+  const currentTemp = temperatures[0];
+
+  // Create a simple ASCII-style chart
+  const chartHeight = 100;
+  const chartData = temperatures.slice(0, 12).map((temp, index) => {
+    const hour = new Date(times[index]).getHours();
+    const normalizedHeight = ((temp - minTemp) / (maxTemp - minTemp)) * chartHeight;
+    return {
+      hour: hour.toString().padStart(2, '0') + ':00',
+      temp: Math.round(temp),
+      height: normalizedHeight,
+    };
+  });
+
+  return (
+    <Box>
+      <Box textAlign="center" margin={{ bottom: 'l' }}>
+        <Box fontSize="heading-xl">{Math.round(currentTemp)}°C</Box>
+        <Box variant="small" color="text-status-inactive">
+          Range: {Math.round(minTemp)}° - {Math.round(maxTemp)}°C
+        </Box>
+      </Box>
+
+      <Box>
+        <Box variant="h3" margin={{ bottom: 's' }}>
+          Next 12 Hours
+        </Box>
+        <div style={{ display: 'flex', alignItems: 'end', height: '120px', gap: '8px', overflow: 'auto' }}>
+          {chartData.map((point, index) => (
+            <div
+              key={index}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                minWidth: '60px',
+              }}
+            >
+              <div style={{ fontSize: '12px', marginBottom: '4px' }}>{point.temp}°</div>
+              <div
+                style={{
+                  width: '12px',
+                  height: `${Math.max(point.height, 10)}px`,
+                  backgroundColor: point.temp > currentTemp ? '#d91515' : '#1d8102',
+                  borderRadius: '2px',
+                  marginBottom: '4px',
+                }}
+              />
+              <div style={{ fontSize: '10px', color: '#5f6b7a' }}>{point.hour}</div>
+            </div>
+          ))}
+        </div>
+      </Box>
+    </Box>
+  );
+}
+
+export const temperature: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 2, defaultColumnSpan: 3 },
+  data: {
+    icon: 'trending-up',
+    title: 'Temperature Trend',
+    description: '24-hour temperature visualization',
+    header: TemperatureHeader,
+    content: TemperatureWidget,
+    staticMinHeight: 200,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/weather-alerts/index.tsx
+++ b/src/pages/weather-dashboard/widgets/weather-alerts/index.tsx
@@ -1,0 +1,182 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Alert from '@cloudscape-design/components/alert';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPIResponse } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function WeatherAlertsHeader() {
+  return (
+    <Header variant="h2" description="Weather warnings and alerts">
+      Weather Alerts
+    </Header>
+  );
+}
+
+interface WeatherAlert {
+  id: string;
+  type: 'error' | 'warning' | 'info';
+  title: string;
+  message: string;
+  timestamp: string;
+}
+
+function WeatherAlertsWidget() {
+  const [alerts, setAlerts] = useState<WeatherAlert[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAndAnalyzeWeather = async () => {
+      try {
+        setLoading(true);
+        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+
+        // Generate alerts based on weather conditions
+        const generatedAlerts: WeatherAlert[] = [];
+        const current = response.current;
+        const hourly = response.hourly;
+
+        // High wind alert
+        if (current.windSpeed > 30) {
+          generatedAlerts.push({
+            id: 'wind-alert',
+            type: 'warning',
+            title: 'High Wind Warning',
+            message: `Wind speeds of ${Math.round(current.windSpeed)} km/h detected. Exercise caution when outdoors.`,
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        // Heavy precipitation alert
+        const totalPrecipitation = hourly.precipitation.slice(0, 6).reduce((sum, val) => sum + val, 0);
+        if (totalPrecipitation > 10) {
+          generatedAlerts.push({
+            id: 'rain-alert',
+            type: 'warning',
+            title: 'Heavy Rain Alert',
+            message: `${totalPrecipitation.toFixed(1)}mm of rain expected in the next 6 hours. Flooding possible in low-lying areas.`,
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        // Extreme temperature alert
+        if (current.temperature > 35) {
+          generatedAlerts.push({
+            id: 'heat-alert',
+            type: 'error',
+            title: 'Heat Warning',
+            message: `Extreme heat of ${Math.round(current.temperature)}°C. Stay hydrated and avoid prolonged sun exposure.`,
+            timestamp: new Date().toISOString(),
+          });
+        } else if (current.temperature < -10) {
+          generatedAlerts.push({
+            id: 'cold-alert',
+            type: 'error',
+            title: 'Extreme Cold Warning',
+            message: `Dangerous cold temperature of ${Math.round(current.temperature)}°C. Dress warmly and limit outdoor exposure.`,
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        // UV Index alert
+        if (current.uvIndex > 8) {
+          generatedAlerts.push({
+            id: 'uv-alert',
+            type: 'warning',
+            title: 'High UV Index',
+            message: `UV Index of ${current.uvIndex}. Use sunscreen and protective clothing when outdoors.`,
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        // Low visibility alert (if available)
+        if (current.visibility < 1000) {
+          generatedAlerts.push({
+            id: 'visibility-alert',
+            type: 'warning',
+            title: 'Low Visibility',
+            message: `Visibility reduced to ${current.visibility}m due to weather conditions. Drive carefully.`,
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        // Good weather info
+        if (generatedAlerts.length === 0) {
+          generatedAlerts.push({
+            id: 'good-weather',
+            type: 'info',
+            title: 'Fair Weather',
+            message: 'Current weather conditions are pleasant with no active warnings.',
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        setAlerts(generatedAlerts);
+      } catch (err) {
+        setAlerts([
+          {
+            id: 'error-alert',
+            type: 'error',
+            title: 'Weather Data Unavailable',
+            message: 'Unable to retrieve current weather data for alerts.',
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAndAnalyzeWeather();
+
+    // Refresh every 15 minutes
+    const interval = setInterval(fetchAndAnalyzeWeather, 15 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="loading">Checking for weather alerts...</StatusIndicator>
+      </Box>
+    );
+  }
+
+  return (
+    <SpaceBetween size="s">
+      {alerts.map(alert => (
+        <Alert key={alert.id} type={alert.type} header={alert.title} dismissible>
+          {alert.message}
+          <Box variant="small" margin={{ top: 's' }} color="text-status-inactive">
+            {new Date(alert.timestamp).toLocaleString()}
+          </Box>
+        </Alert>
+      ))}
+
+      {alerts.length === 0 && (
+        <Box textAlign="center" padding="l">
+          <StatusIndicator type="success">No active weather alerts</StatusIndicator>
+        </Box>
+      )}
+    </SpaceBetween>
+  );
+}
+
+export const weatherAlerts: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 2, defaultColumnSpan: 2 },
+  data: {
+    icon: 'notification',
+    title: 'Weather Alerts',
+    description: 'Active weather warnings and advisories',
+    header: WeatherAlertsHeader,
+    content: WeatherAlertsWidget,
+    staticMinHeight: 200,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/weather-alerts/index.tsx
+++ b/src/pages/weather-dashboard/widgets/weather-alerts/index.tsx
@@ -8,7 +8,8 @@ import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import Alert from '@cloudscape-design/components/alert';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 
-import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPI } from '../../services/weather-api';
+import { useWeatherContext } from '../../context/weather-context';
 import { WeatherAPIResponse } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
 
@@ -31,12 +32,13 @@ interface WeatherAlert {
 function WeatherAlertsWidget() {
   const [alerts, setAlerts] = useState<WeatherAlert[]>([]);
   const [loading, setLoading] = useState(true);
+  const { currentLocation } = useWeatherContext();
 
   useEffect(() => {
     const fetchAndAnalyzeWeather = async () => {
       try {
         setLoading(true);
-        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+        const response = await WeatherAPI.getCurrentWeather(currentLocation);
 
         // Generate alerts based on weather conditions
         const generatedAlerts: WeatherAlert[] = [];
@@ -139,7 +141,7 @@ function WeatherAlertsWidget() {
     // Refresh every 15 minutes
     const interval = setInterval(fetchAndAnalyzeWeather, 15 * 60 * 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [currentLocation]);
 
   if (loading) {
     return (

--- a/src/pages/weather-dashboard/widgets/wind/index.tsx
+++ b/src/pages/weather-dashboard/widgets/wind/index.tsx
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { CurrentWeatherData } from '../interfaces';
+import { WeatherWidgetConfig } from '../interfaces';
+
+function WindHeader() {
+  return (
+    <Header variant="h2" description="Wind speed and direction">
+      Wind Conditions
+    </Header>
+  );
+}
+
+function WindWidget() {
+  const [weatherData, setWeatherData] = useState<CurrentWeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+        setWeatherData(response.current);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch wind data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
+    const interval = setInterval(fetchData, 15 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner size="large" />
+        <Box variant="p" margin={{ top: 's' }}>
+          Loading wind data...
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="error">{error}</StatusIndicator>
+      </Box>
+    );
+  }
+
+  if (!weatherData) {
+    return (
+      <Box textAlign="center" padding="l">
+        <StatusIndicator type="warning">No wind data available</StatusIndicator>
+      </Box>
+    );
+  }
+
+  const getWindDirection = (degrees: number): string => {
+    const directions = [
+      'N',
+      'NNE',
+      'NE',
+      'ENE',
+      'E',
+      'ESE',
+      'SE',
+      'SSE',
+      'S',
+      'SSW',
+      'SW',
+      'WSW',
+      'W',
+      'WNW',
+      'NW',
+      'NNW',
+    ];
+    const index = Math.round(degrees / 22.5) % 16;
+    return directions[index];
+  };
+
+  const getWindStrength = (speed: number): { description: string; emoji: string } => {
+    if (speed < 5) return { description: 'Calm', emoji: '🍃' };
+    if (speed < 15) return { description: 'Light breeze', emoji: '💨' };
+    if (speed < 25) return { description: 'Moderate wind', emoji: '🌬️' };
+    if (speed < 40) return { description: 'Strong wind', emoji: '💨' };
+    return { description: 'Very strong wind', emoji: '🌪️' };
+  };
+
+  const windDirection = getWindDirection(weatherData.windDirection);
+  const windStrength = getWindStrength(weatherData.windSpeed);
+
+  // Create a simple wind direction arrow
+  const arrowRotation = weatherData.windDirection;
+
+  return (
+    <Box>
+      <Box textAlign="center" margin={{ bottom: 'l' }}>
+        <Box fontSize="display-l" margin={{ bottom: 'xs' }}>
+          {windStrength.emoji}
+        </Box>
+        <Box fontSize="heading-xl" margin={{ bottom: 'xs' }}>
+          {Math.round(weatherData.windSpeed)} km/h
+        </Box>
+        <Box variant="p" color="text-status-inactive">
+          {windStrength.description}
+        </Box>
+      </Box>
+
+      <Box textAlign="center" margin={{ bottom: 'l' }}>
+        <div
+          style={{
+            display: 'inline-block',
+            fontSize: '24px',
+            transform: `rotate(${arrowRotation}deg)`,
+            transition: 'transform 0.3s ease',
+          }}
+        >
+          ↑
+        </div>
+        <Box variant="small" margin={{ top: 'xs' }}>
+          {windDirection} ({weatherData.windDirection}°)
+        </Box>
+      </Box>
+
+      <KeyValuePairs
+        columns={2}
+        items={[
+          {
+            label: 'Direction',
+            value: `${windDirection}`,
+          },
+          {
+            label: 'Degrees',
+            value: `${weatherData.windDirection}°`,
+          },
+          {
+            label: 'Speed',
+            value: `${Math.round(weatherData.windSpeed)} km/h`,
+          },
+          {
+            label: 'Condition',
+            value: windStrength.description,
+          },
+        ]}
+      />
+    </Box>
+  );
+}
+
+export const wind: WeatherWidgetConfig = {
+  definition: { defaultRowSpan: 2, defaultColumnSpan: 2 },
+  data: {
+    icon: 'arrow-right',
+    title: 'Wind Conditions',
+    description: 'Current wind speed and direction',
+    header: WindHeader,
+    content: WindWidget,
+    staticMinHeight: 200,
+  },
+};

--- a/src/pages/weather-dashboard/widgets/wind/index.tsx
+++ b/src/pages/weather-dashboard/widgets/wind/index.tsx
@@ -8,7 +8,8 @@ import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 
-import { WeatherAPI, DEFAULT_LOCATIONS } from '../../services/weather-api';
+import { WeatherAPI } from '../../services/weather-api';
+import { useWeatherContext } from '../../context/weather-context';
 import { CurrentWeatherData } from '../interfaces';
 import { WeatherWidgetConfig } from '../interfaces';
 
@@ -24,13 +25,14 @@ function WindWidget() {
   const [weatherData, setWeatherData] = useState<CurrentWeatherData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { currentLocation } = useWeatherContext();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await WeatherAPI.getCurrentWeather(DEFAULT_LOCATIONS[0]);
+        const response = await WeatherAPI.getCurrentWeather(currentLocation);
         setWeatherData(response.current);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch wind data');
@@ -43,7 +45,7 @@ function WindWidget() {
 
     const interval = setInterval(fetchData, 15 * 60 * 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [currentLocation]);
 
   if (loading) {
     return (


### PR DESCRIPTION
Adds a new weather dashboard demo to the Cloudscape Design demos project. The implementation includes:

- New weather dashboard entry added to the main demos list
- Complete weather dashboard application with real-time data from Open-Meteo API
- Multiple weather widgets including current conditions, forecast, temperature trends, precipitation, wind, humidity, alerts, and location overview
- Responsive grid layout with 8 different weather components
- Weather API service for data fetching and processing
- TypeScript interfaces for type safety
- SCSS modules for component styling
- Error handling and loading states for all API calls
- Automatic data refresh intervals for live updates

The dashboard follows existing project patterns and uses Cloudscape Design components throughout.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/zen-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->