### PR TITLE
Add weather dashboard with city search and forecast

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Search cities and view detailed weather information.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/weather-dashboard/api.ts
+++ b/src/pages/weather-dashboard/api.ts
@@ -1,0 +1,154 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { GeocodingResponse, WeatherResponse } from './types';
+
+const GEOCODING_API_BASE = 'https://geocoding.open-meteo.com/v1';
+const WEATHER_API_BASE = 'https://api.open-meteo.com/v1';
+
+export async function searchCities(query: string): Promise<GeocodingResponse> {
+  const params = new URLSearchParams({
+    name: query,
+    count: '10',
+    language: 'en',
+    format: 'json',
+  });
+
+  const response = await fetch(`${GEOCODING_API_BASE}/search?${params}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to search cities: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function getWeatherData(latitude: number, longitude: number): Promise<WeatherResponse> {
+  const currentParams = [
+    'temperature_2m',
+    'relative_humidity_2m',
+    'apparent_temperature',
+    'is_day',
+    'precipitation',
+    'rain',
+    'showers',
+    'snowfall',
+    'weather_code',
+    'cloud_cover',
+    'pressure_msl',
+    'surface_pressure',
+    'wind_speed_10m',
+    'wind_direction_10m',
+    'wind_gusts_10m',
+  ].join(',');
+
+  const dailyParams = [
+    'weather_code',
+    'temperature_2m_max',
+    'temperature_2m_min',
+    'apparent_temperature_max',
+    'apparent_temperature_min',
+    'sunrise',
+    'sunset',
+    'uv_index_max',
+    'precipitation_sum',
+    'rain_sum',
+    'showers_sum',
+    'snowfall_sum',
+    'precipitation_hours',
+    'wind_speed_10m_max',
+    'wind_gusts_10m_max',
+    'wind_direction_10m_dominant',
+  ].join(',');
+
+  const params = new URLSearchParams({
+    latitude: latitude.toString(),
+    longitude: longitude.toString(),
+    current: currentParams,
+    daily: dailyParams,
+    timezone: 'auto',
+    forecast_days: '7',
+  });
+
+  const response = await fetch(`${WEATHER_API_BASE}/forecast?${params}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch weather data: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export function getWeatherDescription(weatherCode: number): string {
+  const weatherCodes: Record<number, string> = {
+    0: 'Clear sky',
+    1: 'Mainly clear',
+    2: 'Partly cloudy',
+    3: 'Overcast',
+    45: 'Fog',
+    48: 'Depositing rime fog',
+    51: 'Light drizzle',
+    53: 'Moderate drizzle',
+    55: 'Dense drizzle',
+    56: 'Light freezing drizzle',
+    57: 'Dense freezing drizzle',
+    61: 'Slight rain',
+    63: 'Moderate rain',
+    65: 'Heavy rain',
+    66: 'Light freezing rain',
+    67: 'Heavy freezing rain',
+    71: 'Slight snow fall',
+    73: 'Moderate snow fall',
+    75: 'Heavy snow fall',
+    77: 'Snow grains',
+    80: 'Slight rain showers',
+    81: 'Moderate rain showers',
+    82: 'Violent rain showers',
+    85: 'Slight snow showers',
+    86: 'Heavy snow showers',
+    95: 'Thunderstorm',
+    96: 'Thunderstorm with slight hail',
+    99: 'Thunderstorm with heavy hail',
+  };
+
+  return weatherCodes[weatherCode] || 'Unknown';
+}
+
+export function getWeatherIcon(weatherCode: number, isDay: boolean): string {
+  if (weatherCode === 0) return isDay ? '☀️' : '🌙';
+  if (weatherCode <= 3) return isDay ? '⛅' : '☁️';
+  if (weatherCode === 45 || weatherCode === 48) return '🌫️';
+  if (weatherCode >= 51 && weatherCode <= 57) return '🌦️';
+  if (weatherCode >= 61 && weatherCode <= 67) return '🌧️';
+  if (weatherCode >= 71 && weatherCode <= 77) return '❄️';
+  if (weatherCode >= 80 && weatherCode <= 86) return '🌧️';
+  if (weatherCode >= 95) return '⛈️';
+  return '🌤️';
+}
+
+export function formatTemperature(temp: number, unit: string): string {
+  return `${Math.round(temp)}${unit}`;
+}
+
+export function formatWindDirection(degrees: number): string {
+  const directions = [
+    'N',
+    'NNE',
+    'NE',
+    'ENE',
+    'E',
+    'ESE',
+    'SE',
+    'SSE',
+    'S',
+    'SSW',
+    'SW',
+    'WSW',
+    'W',
+    'WNW',
+    'NW',
+    'NNW',
+  ];
+  const index = Math.round(degrees / 22.5) % 16;
+  return directions[index];
+}

--- a/src/pages/weather-dashboard/api.ts
+++ b/src/pages/weather-dashboard/api.ts
@@ -11,7 +11,6 @@ export async function searchCities(query: string): Promise<GeocodingResponse> {
     name: query,
     count: '10',
     language: 'en',
-    format: 'json',
   });
 
   const response = await fetch(`${GEOCODING_API_BASE}/search?${params}`);

--- a/src/pages/weather-dashboard/api.ts
+++ b/src/pages/weather-dashboard/api.ts
@@ -13,13 +13,28 @@ export async function searchCities(query: string): Promise<GeocodingResponse> {
     language: 'en',
   });
 
-  const response = await fetch(`${GEOCODING_API_BASE}/search?${params}`);
+  const url = `${GEOCODING_API_BASE}/search?${params}`;
+  console.log('Fetching geocoding data from:', url);
 
-  if (!response.ok) {
-    throw new Error(`Failed to search cities: ${response.statusText}`);
+  try {
+    const response = await fetch(url);
+
+    console.log('Response status:', response.status);
+    console.log('Response headers:', Object.fromEntries(response.headers.entries()));
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('API Error response:', errorText);
+      throw new Error(`Failed to search cities: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const data = await response.json();
+    console.log('Geocoding API response:', data);
+    return data;
+  } catch (error) {
+    console.error('Fetch error:', error);
+    throw error;
   }
-
-  return response.json();
 }
 
 export async function getWeatherData(latitude: number, longitude: number): Promise<WeatherResponse> {

--- a/src/pages/weather-dashboard/api.ts
+++ b/src/pages/weather-dashboard/api.ts
@@ -3,8 +3,8 @@
 
 import { GeocodingResponse, WeatherResponse } from './types';
 
-const GEOCODING_API_BASE = 'https://geocoding.open-meteo.com/v1';
-const WEATHER_API_BASE = 'https://api.open-meteo.com/v1';
+const GEOCODING_API_BASE = '/api/geocoding';
+const WEATHER_API_BASE = '/api/weather';
 
 export async function searchCities(query: string): Promise<GeocodingResponse> {
   const params = new URLSearchParams({
@@ -135,7 +135,7 @@ export function getWeatherIcon(weatherCode: number, isDay: boolean): string {
   if (weatherCode >= 51 && weatherCode <= 57) return '🌦️';
   if (weatherCode >= 61 && weatherCode <= 67) return '🌧️';
   if (weatherCode >= 71 && weatherCode <= 77) return '❄️';
-  if (weatherCode >= 80 && weatherCode <= 86) return '🌧️';
+  if (weatherCode >= 80 && weatherCode <= 86) return '���️';
   if (weatherCode >= 95) return '⛈️';
   return '🌤️';
 }

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useState, useCallback } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Container from '@cloudscape-design/components/container';
+import Box from '@cloudscape-design/components/box';
+import Alert from '@cloudscape-design/components/alert';
+import Spinner from '@cloudscape-design/components/spinner';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+
+import { getWeatherData } from './api';
+import { WeatherResponse, SelectedLocation } from './types';
+import { CitySearch } from './components/city-search';
+import { CurrentWeather } from './components/current-weather';
+import { WeatherForecast } from './components/weather-forecast';
+import { WeatherDetails } from './components/weather-details';
+
+export function App() {
+  const [selectedLocation, setSelectedLocation] = useState<SelectedLocation | null>(null);
+  const [weatherData, setWeatherData] = useState<WeatherResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLocationSelect = useCallback(async (location: SelectedLocation) => {
+    setSelectedLocation(location);
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getWeatherData(location.latitude, location.longitude);
+      setWeatherData(data);
+    } catch (err) {
+      console.error('Error fetching weather data:', err);
+      setError('Failed to fetch weather data. Please try again.');
+      setWeatherData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Home', href: '/' },
+            { text: 'Weather Dashboard', href: '/weather-dashboard' },
+          ]}
+          ariaLabel="Breadcrumbs"
+        />
+      }
+      content={
+        <ContentLayout
+          header={
+            <Header
+              variant="h1"
+              description="Search for any city and get detailed weather information including current conditions and 7-day forecast."
+            >
+              Weather Dashboard
+            </Header>
+          }
+        >
+          <SpaceBetween size="l">
+            <Container>
+              <Box variant="h2" margin={{ bottom: 'm' }}>
+                Search Location
+              </Box>
+              <CitySearch onLocationSelect={handleLocationSelect} loading={loading} />
+            </Container>
+
+            {error && (
+              <Alert type="error" dismissible onDismiss={() => setError(null)}>
+                {error}
+              </Alert>
+            )}
+
+            {loading && (
+              <Container>
+                <Box textAlign="center" padding="l">
+                  <Spinner size="large" />
+                  <Box variant="p" margin={{ top: 'm' }}>
+                    Loading weather data...
+                  </Box>
+                </Box>
+              </Container>
+            )}
+
+            {!loading && selectedLocation && weatherData && (
+              <SpaceBetween size="l">
+                <CurrentWeather location={selectedLocation} weatherData={weatherData} />
+                <WeatherForecast weatherData={weatherData} />
+                <WeatherDetails weatherData={weatherData} />
+              </SpaceBetween>
+            )}
+
+            {!selectedLocation && !loading && (
+              <Container>
+                <Box textAlign="center" padding="xl" color="text-body-secondary">
+                  <Box fontSize="display-l" margin={{ bottom: 'm' }}>
+                    🌤️
+                  </Box>
+                  <Box variant="h2" margin={{ bottom: 's' }}>
+                    Get Started
+                  </Box>
+                  <Box variant="p">
+                    Search for a city above to view detailed weather information including current conditions, 7-day
+                    forecast, and more.
+                  </Box>
+                </Box>
+              </Container>
+            )}
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/weather-dashboard/components/city-search.tsx
+++ b/src/pages/weather-dashboard/components/city-search.tsx
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useState, useCallback } from 'react';
+import Autosuggest from '@cloudscape-design/components/autosuggest';
+import Box from '@cloudscape-design/components/box';
+import { DropdownStatusProps } from '@cloudscape-design/components/internal/components/dropdown-status';
+
+import { searchCities } from '../api';
+import { GeocodingResult, SelectedLocation } from '../types';
+
+interface CitySearchProps {
+  onLocationSelect: (location: SelectedLocation) => void;
+  loading?: boolean;
+}
+
+export function CitySearch({ onLocationSelect, loading }: CitySearchProps) {
+  const [value, setValue] = useState('');
+  const [options, setOptions] = useState<Array<{ value: string; label: string; data: GeocodingResult }>>([]);
+  const [status, setStatus] = useState<DropdownStatusProps.StatusType>('finished');
+
+  const handleLoadItems = useCallback(async ({ detail }: { detail: { filteringText: string } }) => {
+    const query = detail.filteringText.trim();
+
+    if (query.length < 2) {
+      setOptions([]);
+      setStatus('finished');
+      return;
+    }
+
+    setStatus('loading');
+
+    try {
+      const response = await searchCities(query);
+      const results = response.results || [];
+
+      const formattedOptions = results.map(result => ({
+        value: `${result.name}, ${result.country}`,
+        label: `${result.name}, ${result.admin1 ? `${result.admin1}, ` : ''}${result.country}`,
+        data: result,
+      }));
+
+      setOptions(formattedOptions);
+      setStatus('finished');
+    } catch (error) {
+      console.error('Error searching cities:', error);
+      setOptions([]);
+      setStatus('error');
+    }
+  }, []);
+
+  const handleSelect = ({ detail }: { detail: { value: string } }) => {
+    const selectedOption = options.find(option => option.value === detail.value);
+    if (selectedOption) {
+      const location: SelectedLocation = {
+        name: selectedOption.data.name,
+        latitude: selectedOption.data.latitude,
+        longitude: selectedOption.data.longitude,
+        country: selectedOption.data.country,
+        admin1: selectedOption.data.admin1,
+        timezone: selectedOption.data.timezone,
+      };
+      onLocationSelect(location);
+      setValue(detail.value);
+    }
+  };
+
+  return (
+    <Box>
+      <Autosuggest
+        value={value}
+        onChange={({ detail }) => setValue(detail.value)}
+        onSelect={handleSelect}
+        onLoadItems={handleLoadItems}
+        options={options}
+        statusType={status}
+        placeholder="Search for a city..."
+        loadingText="Searching cities..."
+        finishedText={options.length === 0 && value.length >= 2 ? 'No cities found' : undefined}
+        errorText="Error searching cities"
+        empty="Start typing to search for cities"
+        enteredTextLabel={value => `Use "${value}"`}
+        ariaLabel="City search"
+        disabled={loading}
+      />
+    </Box>
+  );
+}

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Badge from '@cloudscape-design/components/badge';
+
+import { WeatherResponse, SelectedLocation } from '../types';
+import { getWeatherDescription, getWeatherIcon, formatTemperature, formatWindDirection } from '../api';
+
+interface CurrentWeatherProps {
+  location: SelectedLocation;
+  weatherData: WeatherResponse;
+}
+
+export function CurrentWeather({ location, weatherData }: CurrentWeatherProps) {
+  const { current, current_units } = weatherData;
+  const weatherIcon = getWeatherIcon(current.weather_code, current.is_day === 1);
+  const weatherDescription = getWeatherDescription(current.weather_code);
+
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleString();
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2">
+          Current Weather
+          <Box variant="small" color="text-body-secondary" margin={{ left: 'xs' }}>
+            Last updated: {formatTime(current.time)}
+          </Box>
+        </Header>
+      }
+    >
+      <ColumnLayout columns={2} variant="text-grid">
+        <div>
+          <Box variant="h1" textAlign="center" margin={{ bottom: 'm' }}>
+            <div style={{ fontSize: '4rem', marginBottom: '0.5rem' }}>{weatherIcon}</div>
+            <div>{formatTemperature(current.temperature_2m, current_units.temperature_2m)}</div>
+          </Box>
+          <Box textAlign="center" variant="h3" color="text-body-secondary">
+            {weatherDescription}
+          </Box>
+          <Box textAlign="center" margin={{ top: 's' }}>
+            <Badge color={current.is_day ? 'blue' : 'grey'}>{current.is_day ? 'Day' : 'Night'}</Badge>
+          </Box>
+        </div>
+
+        <div>
+          <KeyValuePairs
+            columns={1}
+            items={[
+              {
+                label: 'Location',
+                value: `${location.name}, ${location.admin1 ? `${location.admin1}, ` : ''}${location.country}`,
+              },
+              {
+                label: 'Feels like',
+                value: formatTemperature(current.apparent_temperature, current_units.apparent_temperature),
+              },
+              {
+                label: 'Humidity',
+                value: `${current.relative_humidity_2m}${current_units.relative_humidity_2m}`,
+              },
+              {
+                label: 'Precipitation',
+                value: `${current.precipitation}${current_units.precipitation}`,
+              },
+              {
+                label: 'Wind',
+                value: `${current.wind_speed_10m}${current_units.wind_speed_10m} ${formatWindDirection(current.wind_direction_10m)}`,
+              },
+              {
+                label: 'Wind gusts',
+                value: `${current.wind_gusts_10m}${current_units.wind_gusts_10m}`,
+              },
+              {
+                label: 'Pressure',
+                value: `${Math.round(current.pressure_msl)}${current_units.pressure_msl}`,
+              },
+              {
+                label: 'Cloud cover',
+                value: `${current.cloud_cover}${current_units.cloud_cover}`,
+              },
+            ]}
+          />
+        </div>
+      </ColumnLayout>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -53,43 +53,7 @@ export function CurrentWeather({ location, weatherData }: CurrentWeatherProps) {
         </div>
 
         <div>
-          <KeyValuePairs
-            columns={1}
-            items={[
-              {
-                label: 'Location',
-                value: `${location.name}, ${location.admin1 ? `${location.admin1}, ` : ''}${location.country}`,
-              },
-              {
-                label: 'Feels like',
-                value: formatTemperature(current.apparent_temperature, current_units.apparent_temperature),
-              },
-              {
-                label: 'Humidity',
-                value: `${current.relative_humidity_2m}${current_units.relative_humidity_2m}`,
-              },
-              {
-                label: 'Precipitation',
-                value: `${current.precipitation}${current_units.precipitation}`,
-              },
-              {
-                label: 'Wind',
-                value: `${current.wind_speed_10m}${current_units.wind_speed_10m} ${formatWindDirection(current.wind_direction_10m)}`,
-              },
-              {
-                label: 'Wind gusts',
-                value: `${current.wind_gusts_10m}${current_units.wind_gusts_10m}`,
-              },
-              {
-                label: 'Pressure',
-                value: `${Math.round(current.pressure_msl)}${current_units.pressure_msl}`,
-              },
-              {
-                label: 'Cloud cover',
-                value: `${current.cloud_cover}${current_units.cloud_cover}`,
-              },
-            ]}
-          />
+          <KeyValuePairs columns={1} items={createWeatherDetailsItems(location, current, current_units)} />
         </div>
       </ColumnLayout>
     </Container>

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -10,7 +10,8 @@ import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Badge from '@cloudscape-design/components/badge';
 
 import { WeatherResponse, SelectedLocation } from '../types';
-import { getWeatherDescription, getWeatherIcon, formatTemperature, formatWindDirection } from '../api';
+import { getWeatherDescription, getWeatherIcon, formatTemperature } from '../api';
+import { createWeatherDetailsItems } from '../constants';
 
 interface CurrentWeatherProps {
   location: SelectedLocation;

--- a/src/pages/weather-dashboard/components/weather-details.tsx
+++ b/src/pages/weather-dashboard/components/weather-details.tsx
@@ -1,0 +1,109 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import Box from '@cloudscape-design/components/box';
+
+import { WeatherResponse } from '../types';
+import { formatWindDirection } from '../api';
+
+interface WeatherDetailsProps {
+  weatherData: WeatherResponse;
+}
+
+export function WeatherDetails({ weatherData }: WeatherDetailsProps) {
+  const { current, current_units, daily, daily_units } = weatherData;
+
+  const todayIndex = 0;
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  };
+
+  return (
+    <ColumnLayout columns={2}>
+      <Container header={<Header variant="h3">Detailed Conditions</Header>}>
+        <KeyValuePairs
+          columns={1}
+          items={[
+            {
+              label: 'Real Feel',
+              value: `${Math.round(current.apparent_temperature)}${current_units.apparent_temperature}`,
+            },
+            {
+              label: 'Wind',
+              value: `${current.wind_speed_10m}${current_units.wind_speed_10m} ${formatWindDirection(current.wind_direction_10m)}`,
+            },
+            {
+              label: 'Wind Gusts',
+              value: `${current.wind_gusts_10m}${current_units.wind_gusts_10m}`,
+            },
+            {
+              label: 'Humidity',
+              value: `${current.relative_humidity_2m}${current_units.relative_humidity_2m}`,
+            },
+            {
+              label: 'Pressure',
+              value: `${Math.round(current.pressure_msl)} ${current_units.pressure_msl}`,
+            },
+            {
+              label: 'Surface Pressure',
+              value: `${Math.round(current.surface_pressure)} ${current_units.surface_pressure}`,
+            },
+            {
+              label: 'Cloud Cover',
+              value: `${current.cloud_cover}${current_units.cloud_cover}`,
+            },
+            {
+              label: 'Visibility',
+              value: current.is_day ? 'Day' : 'Night',
+            },
+          ]}
+        />
+      </Container>
+
+      <Container header={<Header variant="h3">Today's Summary</Header>}>
+        <KeyValuePairs
+          columns={1}
+          items={[
+            {
+              label: 'High / Low',
+              value: `${Math.round(daily.temperature_2m_max[todayIndex])}${daily_units.temperature_2m_max} / ${Math.round(daily.temperature_2m_min[todayIndex])}${daily_units.temperature_2m_min}`,
+            },
+            {
+              label: 'Sunrise',
+              value: formatTime(daily.sunrise[todayIndex]),
+            },
+            {
+              label: 'Sunset',
+              value: formatTime(daily.sunset[todayIndex]),
+            },
+            {
+              label: 'Precipitation',
+              value: `${daily.precipitation_sum[todayIndex]}${daily_units.precipitation_sum}`,
+            },
+            {
+              label: 'Rain',
+              value: `${daily.rain_sum[todayIndex]}${daily_units.rain_sum}`,
+            },
+            {
+              label: 'Snow',
+              value: `${daily.snowfall_sum[todayIndex]}${daily_units.snowfall_sum}`,
+            },
+            {
+              label: 'UV Index',
+              value: `${daily.uv_index_max[todayIndex]}`,
+            },
+            {
+              label: 'Max Wind Speed',
+              value: `${daily.wind_speed_10m_max[todayIndex]}${daily_units.wind_speed_10m_max} ${formatWindDirection(daily.wind_direction_10m_dominant[todayIndex])}`,
+            },
+          ]}
+        />
+      </Container>
+    </ColumnLayout>
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-forecast.tsx
+++ b/src/pages/weather-dashboard/components/weather-forecast.tsx
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+
+import { WeatherResponse } from '../types';
+import { getWeatherDescription, getWeatherIcon, formatTemperature, formatWindDirection } from '../api';
+
+interface WeatherForecastProps {
+  weatherData: WeatherResponse;
+}
+
+export function WeatherForecast({ weatherData }: WeatherForecastProps) {
+  const { daily, daily_units } = weatherData;
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    } else if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    } else {
+      return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+    }
+  };
+
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  };
+
+  return (
+    <Container header={<Header variant="h2">7-Day Forecast</Header>}>
+      <ColumnLayout columns={7} variant="text-grid">
+        {daily.time.map((date, index) => {
+          const weatherIcon = getWeatherIcon(daily.weather_code[index], true);
+          const weatherDescription = getWeatherDescription(daily.weather_code[index]);
+
+          return (
+            <Box key={date} textAlign="center" padding={{ vertical: 'm' }}>
+              <Box variant="h4" margin={{ bottom: 's' }}>
+                {formatDate(date)}
+              </Box>
+
+              <Box fontSize="display-l" margin={{ bottom: 's' }}>
+                {weatherIcon}
+              </Box>
+
+              <Box variant="small" color="text-body-secondary" margin={{ bottom: 's' }}>
+                {weatherDescription}
+              </Box>
+
+              <Box margin={{ bottom: 's' }}>
+                <Box variant="span" fontWeight="bold">
+                  {formatTemperature(daily.temperature_2m_max[index], daily_units.temperature_2m_max)}
+                </Box>
+                <Box variant="span" color="text-body-secondary" margin={{ left: 'xxs' }}>
+                  / {formatTemperature(daily.temperature_2m_min[index], daily_units.temperature_2m_min)}
+                </Box>
+              </Box>
+
+              <Box variant="small" color="text-body-secondary" margin={{ bottom: 'xs' }}>
+                <div>
+                  💧 {daily.precipitation_sum[index]}
+                  {daily_units.precipitation_sum}
+                </div>
+                <div>
+                  💨 {daily.wind_speed_10m_max[index]}
+                  {daily_units.wind_speed_10m_max}
+                </div>
+                <div>☀️ UV {daily.uv_index_max[index]}</div>
+              </Box>
+
+              <Box variant="small" color="text-body-secondary">
+                <div>🌅 {formatTime(daily.sunrise[index])}</div>
+                <div>🌅 {formatTime(daily.sunset[index])}</div>
+              </Box>
+            </Box>
+          );
+        })}
+      </ColumnLayout>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/constants.ts
+++ b/src/pages/weather-dashboard/constants.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { WeatherResponse, SelectedLocation } from './types';
+import { formatTemperature, formatWindDirection } from './api';
+
+export const createWeatherDetailsItems = (
+  location: SelectedLocation,
+  current: WeatherResponse['current'],
+  current_units: WeatherResponse['current_units'],
+) => [
+  {
+    label: 'Location',
+    value: `${location.name}, ${location.admin1 ? `${location.admin1}, ` : ''}${location.country}`,
+  },
+  {
+    label: 'Feels like',
+    value: formatTemperature(current.apparent_temperature, current_units.apparent_temperature),
+  },
+  {
+    label: 'Humidity',
+    value: `${current.relative_humidity_2m}${current_units.relative_humidity_2m}`,
+  },
+  {
+    label: 'Precipitation',
+    value: `${current.precipitation}${current_units.precipitation}`,
+  },
+  {
+    label: 'Wind',
+    value: `${current.wind_speed_10m}${current_units.wind_speed_10m} ${formatWindDirection(current.wind_direction_10m)}`,
+  },
+  {
+    label: 'Wind gusts',
+    value: `${current.wind_gusts_10m}${current_units.wind_gusts_10m}`,
+  },
+  {
+    label: 'Pressure',
+    value: `${Math.round(current.pressure_msl)}${current_units.pressure_msl}`,
+  },
+  {
+    label: 'Cloud cover',
+    value: `${current.cloud_cover}${current_units.cloud_cover}`,
+  },
+];

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/root.tsx
+++ b/src/pages/weather-dashboard/root.tsx
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { App } from './app';
+
+export default function WeatherDashboardRoot() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/types.ts
+++ b/src/pages/weather-dashboard/types.ts
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface GeocodingResult {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  elevation: number;
+  feature_code: string;
+  country_code: string;
+  admin1: string;
+  admin2: string;
+  admin3: string;
+  admin4: string;
+  timezone: string;
+  population: number;
+  country_id: number;
+  country: string;
+  admin1_id: number;
+  admin2_id: number;
+  admin3_id: number;
+  admin4_id: number;
+}
+
+export interface GeocodingResponse {
+  results?: GeocodingResult[];
+  generationtime_ms: number;
+}
+
+export interface CurrentWeather {
+  time: string;
+  interval: number;
+  temperature_2m: number;
+  relative_humidity_2m: number;
+  apparent_temperature: number;
+  is_day: number;
+  precipitation: number;
+  rain: number;
+  showers: number;
+  snowfall: number;
+  weather_code: number;
+  cloud_cover: number;
+  pressure_msl: number;
+  surface_pressure: number;
+  wind_speed_10m: number;
+  wind_direction_10m: number;
+  wind_gusts_10m: number;
+}
+
+export interface DailyWeather {
+  time: string[];
+  weather_code: number[];
+  temperature_2m_max: number[];
+  temperature_2m_min: number[];
+  apparent_temperature_max: number[];
+  apparent_temperature_min: number[];
+  sunrise: string[];
+  sunset: string[];
+  uv_index_max: number[];
+  precipitation_sum: number[];
+  rain_sum: number[];
+  showers_sum: number[];
+  snowfall_sum: number[];
+  precipitation_hours: number[];
+  wind_speed_10m_max: number[];
+  wind_gusts_10m_max: number[];
+  wind_direction_10m_dominant: number[];
+}
+
+export interface WeatherUnits {
+  time: string;
+  interval: string;
+  temperature_2m: string;
+  relative_humidity_2m: string;
+  apparent_temperature: string;
+  is_day: string;
+  precipitation: string;
+  rain: string;
+  showers: string;
+  snowfall: string;
+  weather_code: string;
+  cloud_cover: string;
+  pressure_msl: string;
+  surface_pressure: string;
+  wind_speed_10m: string;
+  wind_direction_10m: string;
+  wind_gusts_10m: string;
+}
+
+export interface DailyUnits {
+  time: string;
+  weather_code: string;
+  temperature_2m_max: string;
+  temperature_2m_min: string;
+  apparent_temperature_max: string;
+  apparent_temperature_min: string;
+  sunrise: string;
+  sunset: string;
+  uv_index_max: string;
+  precipitation_sum: string;
+  rain_sum: string;
+  showers_sum: string;
+  snowfall_sum: string;
+  precipitation_hours: string;
+  wind_speed_10m_max: string;
+  wind_gusts_10m_max: string;
+  wind_direction_10m_dominant: string;
+}
+
+export interface WeatherResponse {
+  latitude: number;
+  longitude: number;
+  generationtime_ms: number;
+  utc_offset_seconds: number;
+  timezone: string;
+  timezone_abbreviation: string;
+  elevation: number;
+  current_units: WeatherUnits;
+  current: CurrentWeather;
+  daily_units: DailyUnits;
+  daily: DailyWeather;
+}
+
+export interface SelectedLocation {
+  name: string;
+  latitude: number;
+  longitude: number;
+  country: string;
+  admin1: string;
+  timezone: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,5 +26,17 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    proxy: {
+      '/api/geocoding': {
+        target: 'https://geocoding.open-meteo.com/v1',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api\/geocoding/, ''),
+      },
+      '/api/weather': {
+        target: 'https://api.open-meteo.com/v1',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api\/weather/, ''),
+      },
+    },
   },
 });


### PR DESCRIPTION
Add a new weather dashboard page that allows users to search for cities and view detailed weather information.

Changes include:
- Add weather dashboard route to demos list in index.tsx
- Create weather dashboard API module with city search and weather data fetching
- Add weather dashboard main app component with location search and data display
- Create weather forecast component showing 7-day forecast with icons and details
- Add weather details component displaying current conditions and daily metrics
- Create city search component for location selection
- Add TypeScript type definitions for geocoding and weather API responses
- Configure Vite proxy for Open-Meteo geocoding and weather APIs
- Add weather dashboard index and root components for routing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/curry-landing)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->
<!--<branchName>curry-landing</branchName>-->