### PR TITLE
Add weather dashboard with Open Meteo API integration

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather data powered by Open Meteo API.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,133 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useEffect } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Box from '@cloudscape-design/components/box';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import Button from '@cloudscape-design/components/button';
+import { WeatherData, LocationData, WeatherService } from './weather-api';
+import { CurrentWeather } from './components/current-weather';
+import { ForecastChart } from './components/forecast-chart';
+import { DailyForecast } from './components/daily-forecast';
+import { LocationSearch } from './components/location-search';
+
+export function App() {
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [currentLocation, setCurrentLocation] = useState<LocationData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const fetchWeatherData = async (location: LocationData) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await WeatherService.getCurrentWeather(location.latitude, location.longitude);
+      setWeatherData(data);
+      setCurrentLocation(location);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError('Failed to fetch weather data. Please try again.');
+      console.error('Weather fetch error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRefresh = () => {
+    if (currentLocation) {
+      fetchWeatherData(currentLocation);
+    }
+  };
+
+  // Load default location on mount
+  useEffect(() => {
+    const defaultLocation = WeatherService.getDefaultLocations()[0]; // New York
+    fetchWeatherData(defaultLocation);
+  }, []);
+
+  const flashbarItems = error
+    ? [
+        {
+          type: 'error' as const,
+          content: error,
+          dismissible: true,
+          onDismiss: () => setError(null),
+        },
+      ]
+    : [];
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="m">
+              <Header
+                variant="h1"
+                description="Real-time weather data powered by Open Meteo API"
+                actions={
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Button
+                      iconName="refresh"
+                      onClick={handleRefresh}
+                      disabled={loading || !currentLocation}
+                      loading={loading}
+                    >
+                      Refresh
+                    </Button>
+                    <Button iconName="external" iconAlign="right" href="https://open-meteo.com" target="_blank">
+                      Open Meteo API
+                    </Button>
+                  </SpaceBetween>
+                }
+              >
+                Weather Dashboard
+              </Header>
+
+              {flashbarItems.length > 0 && <Flashbar items={flashbarItems} />}
+
+              {lastUpdated && (
+                <Box variant="small" color="text-body-secondary">
+                  Last updated: {lastUpdated.toLocaleString()}
+                </Box>
+              )}
+            </SpaceBetween>
+          }
+        >
+          <SpaceBetween size="l">
+            <LocationSearch onLocationSelect={fetchWeatherData} currentLocation={currentLocation} loading={loading} />
+
+            {weatherData && currentLocation && (
+              <>
+                <Grid gridDefinition={[{ colspan: { default: 12, xs: 12, s: 12, m: 6, l: 6, xl: 6 } }]}>
+                  <CurrentWeather
+                    weather={weatherData}
+                    location={`${currentLocation.name}, ${currentLocation.country}`}
+                  />
+                </Grid>
+
+                <ForecastChart weather={weatherData} />
+
+                <DailyForecast weather={weatherData} />
+              </>
+            )}
+
+            {loading && !weatherData && (
+              <Box textAlign="center" padding="xxl">
+                <Box variant="h3">Loading weather data...</Box>
+              </Box>
+            )}
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/weather-dashboard/components/current-weather.tsx
+++ b/src/pages/weather-dashboard/components/current-weather.tsx
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import { WeatherData, WeatherService } from '../weather-api';
+
+interface CurrentWeatherProps {
+  weather: WeatherData;
+  location: string;
+}
+
+export function CurrentWeather({ weather, location }: CurrentWeatherProps) {
+  const { current } = weather;
+  const weatherDescription = WeatherService.getWeatherDescription(current.weather_code);
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={`Current conditions for ${location}`}>
+          Current Weather
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <ColumnLayout columns={2}>
+          <div>
+            <Box variant="awsui-key-label">Temperature</Box>
+            <Box fontSize="display-l" fontWeight="bold">
+              {Math.round(current.temperature_2m)}°C
+            </Box>
+            <Box variant="small" color="text-body-secondary">
+              {weatherDescription}
+            </Box>
+          </div>
+          <SpaceBetween size="s">
+            <div>
+              <Box variant="awsui-key-label">Humidity</Box>
+              <Box variant="h3">{current.relative_humidity_2m}%</Box>
+            </div>
+            <div>
+              <Box variant="awsui-key-label">Wind Speed</Box>
+              <Box variant="h3">{Math.round(current.wind_speed_10m)} km/h</Box>
+            </div>
+            <div>
+              <Box variant="awsui-key-label">Wind Direction</Box>
+              <Box variant="h3">{current.wind_direction_10m}°</Box>
+            </div>
+          </SpaceBetween>
+        </ColumnLayout>
+
+        <div>
+          <Box variant="awsui-key-label">Last Updated</Box>
+          <Box variant="small" color="text-body-secondary">
+            {new Date(current.time).toLocaleString()}
+          </Box>
+        </div>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/daily-forecast.tsx
+++ b/src/pages/weather-dashboard/components/daily-forecast.tsx
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import { WeatherData, WeatherService } from '../weather-api';
+
+interface DailyForecastProps {
+  weather: WeatherData;
+}
+
+export function DailyForecast({ weather }: DailyForecastProps) {
+  const { daily } = weather;
+
+  const forecastItems = daily.time.map((date, index) => ({
+    date: new Date(date),
+    maxTemp: Math.round(daily.temperature_2m_max[index]),
+    minTemp: Math.round(daily.temperature_2m_min[index]),
+    precipitation: Math.round(daily.precipitation_sum[index] * 10) / 10,
+    windSpeed: Math.round(daily.wind_speed_10m_max[index]),
+    weather: WeatherService.getWeatherDescription(daily.weather_code[index]),
+    weatherCode: daily.weather_code[index],
+  }));
+
+  const getTemperatureColor = (temp: number) => {
+    if (temp >= 30) return 'red';
+    if (temp >= 20) return 'green';
+    if (temp >= 10) return 'blue';
+    return 'grey';
+  };
+
+  const getPrecipitationBadge = (precipitation: number) => {
+    if (precipitation === 0) return <Badge color="grey">No rain</Badge>;
+    if (precipitation < 2) return <Badge color="blue">Light</Badge>;
+    if (precipitation < 10) return <Badge color="green">Moderate</Badge>;
+    return <Badge color="red">Heavy</Badge>;
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="7-day weather forecast">
+          Daily Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'date',
+            header: 'Date',
+            cell: item => (
+              <div>
+                <Box variant="strong">{item.date.toLocaleDateString([], { weekday: 'short' })}</Box>
+                <Box variant="small" color="text-body-secondary">
+                  {item.date.toLocaleDateString([], { month: 'short', day: 'numeric' })}
+                </Box>
+              </div>
+            ),
+            sortingField: 'date',
+            isRowHeader: true,
+          },
+          {
+            id: 'weather',
+            header: 'Conditions',
+            cell: item => <Box variant="span">{item.weather}</Box>,
+          },
+          {
+            id: 'temperature',
+            header: 'Temperature',
+            cell: item => (
+              <div>
+                <Badge color={getTemperatureColor(item.maxTemp)}>{item.maxTemp}°C</Badge>
+                {' / '}
+                <Badge color={getTemperatureColor(item.minTemp)}>{item.minTemp}°C</Badge>
+              </div>
+            ),
+          },
+          {
+            id: 'precipitation',
+            header: 'Precipitation',
+            cell: item => (
+              <div>
+                {getPrecipitationBadge(item.precipitation)}
+                <Box variant="small" color="text-body-secondary">
+                  {item.precipitation} mm
+                </Box>
+              </div>
+            ),
+          },
+          {
+            id: 'wind',
+            header: 'Max Wind',
+            cell: item => `${item.windSpeed} km/h`,
+          },
+        ]}
+        items={forecastItems}
+        loadingText="Loading forecast"
+        trackBy="date"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="strong" textAlign="center" color="inherit">
+              No forecast data available
+            </Box>
+          </Box>
+        }
+        variant="borderless"
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/forecast-chart.tsx
+++ b/src/pages/weather-dashboard/components/forecast-chart.tsx
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import { WeatherData, WeatherService } from '../weather-api';
+
+interface ForecastChartProps {
+  weather: WeatherData;
+}
+
+export function ForecastChart({ weather }: ForecastChartProps) {
+  const { hourly } = weather;
+
+  // Get next 24 hours of data
+  const next24Hours = hourly.time.slice(0, 24).map((time, index) => ({
+    time: new Date(time),
+    temperature: hourly.temperature_2m[index],
+    humidity: hourly.relative_humidity_2m[index],
+    windSpeed: hourly.wind_speed_10m[index],
+    precipitation: hourly.precipitation_probability[index],
+    weatherCode: hourly.weather_code[index],
+  }));
+
+  // Group by 4-hour intervals for display
+  const intervals = [];
+  for (let i = 0; i < next24Hours.length; i += 4) {
+    const interval = next24Hours.slice(i, i + 4);
+    const avgTemp = interval.reduce((sum, h) => sum + h.temperature, 0) / interval.length;
+    const maxPrecip = Math.max(...interval.map(h => h.precipitation));
+
+    intervals.push({
+      timeLabel: interval[0].time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      temperature: Math.round(avgTemp),
+      precipitation: Math.round(maxPrecip),
+      weather: WeatherService.getWeatherDescription(interval[0].weatherCode),
+    });
+  }
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="24-hour temperature and precipitation forecast">
+          Hourly Forecast
+        </Header>
+      }
+    >
+      <div style={{ overflowX: 'auto' }}>
+        <ColumnLayout columns={Math.min(intervals.length, 6)} variant="text-grid">
+          {intervals.map((interval, index) => (
+            <div key={index} style={{ textAlign: 'center', padding: '8px' }}>
+              <Box variant="awsui-key-label">{interval.timeLabel}</Box>
+              <SpaceBetween size="xs">
+                <Box fontSize="heading-m" fontWeight="bold">
+                  {interval.temperature}°C
+                </Box>
+                <Box variant="small" color="text-body-secondary">
+                  {interval.weather}
+                </Box>
+                <Box variant="small">💧 {interval.precipitation}%</Box>
+              </SpaceBetween>
+            </div>
+          ))}
+        </ColumnLayout>
+      </div>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/components/location-search.tsx
+++ b/src/pages/weather-dashboard/components/location-search.tsx
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useEffect } from 'react';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Input from '@cloudscape-design/components/input';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Select from '@cloudscape-design/components/select';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Box from '@cloudscape-design/components/box';
+import { LocationData, WeatherService } from '../weather-api';
+
+interface LocationSearchProps {
+  onLocationSelect: (location: LocationData) => void;
+  currentLocation?: LocationData;
+  loading?: boolean;
+}
+
+export function LocationSearch({ onLocationSelect, currentLocation, loading }: LocationSearchProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<LocationData[]>([]);
+  const [selectedLocation, setSelectedLocation] = useState<{ label: string; value: string } | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  const defaultLocations = WeatherService.getDefaultLocations();
+
+  const searchLocations = async (query: string) => {
+    if (!query.trim()) {
+      setSearchResults([]);
+      return;
+    }
+
+    setSearching(true);
+    try {
+      const results = await WeatherService.searchLocations(query);
+      setSearchResults(results.slice(0, 10));
+    } catch (error) {
+      console.error('Search failed:', error);
+      setSearchResults([]);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleSearch = () => {
+    searchLocations(searchQuery);
+  };
+
+  const handleKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  const handleLocationSelect = () => {
+    if (!selectedLocation) return;
+
+    const location = searchResults.find(result => `${result.name}, ${result.country}` === selectedLocation.value);
+
+    if (location) {
+      onLocationSelect(location);
+    }
+  };
+
+  const handleDefaultLocationSelect = (location: LocationData) => {
+    onLocationSelect(location);
+  };
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (searchQuery.trim()) {
+        searchLocations(searchQuery);
+      }
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
+  }, [searchQuery]);
+
+  const searchOptions = searchResults.map(result => ({
+    label: `${result.name}, ${result.country}${result.admin1 ? `, ${result.admin1}` : ''}`,
+    value: `${result.name}, ${result.country}`,
+  }));
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Search for a city or select from popular locations">
+          Weather Location
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        {currentLocation && (
+          <Box>
+            <Box variant="awsui-key-label">Current Location</Box>
+            <Box variant="strong">
+              {currentLocation.name}, {currentLocation.country}
+            </Box>
+          </Box>
+        )}
+
+        <ColumnLayout columns={2}>
+          <SpaceBetween size="s">
+            <Box variant="h3">Search Locations</Box>
+            <Input
+              value={searchQuery}
+              onChange={({ detail }) => setSearchQuery(detail.value)}
+              onKeyDown={handleKeyPress}
+              placeholder="Enter city name..."
+              disabled={loading}
+            />
+
+            {searchOptions.length > 0 && (
+              <Select
+                selectedOption={selectedLocation}
+                onChange={({ detail }) => setSelectedLocation(detail.selectedOption)}
+                options={searchOptions}
+                placeholder="Select from search results"
+                loadingText={searching ? 'Searching...' : undefined}
+                disabled={loading}
+              />
+            )}
+
+            <Button
+              onClick={handleLocationSelect}
+              disabled={!selectedLocation || loading}
+              loading={loading}
+              variant="primary"
+            >
+              Get Weather
+            </Button>
+          </SpaceBetween>
+
+          <SpaceBetween size="s">
+            <Box variant="h3">Popular Locations</Box>
+            <SpaceBetween size="xs">
+              {defaultLocations.map(location => (
+                <Button
+                  key={`${location.name}-${location.country}`}
+                  onClick={() => handleDefaultLocationSelect(location)}
+                  disabled={loading}
+                  variant="normal"
+                  size="small"
+                >
+                  {location.name}
+                </Button>
+              ))}
+            </SpaceBetween>
+          </SpaceBetween>
+        </ColumnLayout>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/weather-api.ts
+++ b/src/pages/weather-dashboard/weather-api.ts
@@ -1,0 +1,137 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface WeatherData {
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  elevation: number;
+  current: {
+    time: string;
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    wind_speed_10m: number;
+    wind_direction_10m: number;
+    weather_code: number;
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    relative_humidity_2m: number[];
+    wind_speed_10m: number[];
+    precipitation_probability: number[];
+    weather_code: number[];
+  };
+  daily: {
+    time: string[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_sum: number[];
+    wind_speed_10m_max: number[];
+    weather_code: number[];
+  };
+}
+
+export interface LocationData {
+  name: string;
+  latitude: number;
+  longitude: number;
+  country: string;
+  admin1?: string;
+}
+
+// Weather codes mapping for Open Meteo
+export const WEATHER_CODES: Record<number, { description: string; icon: string }> = {
+  0: { description: 'Clear sky', icon: 'sunny' },
+  1: { description: 'Mainly clear', icon: 'partly-cloudy' },
+  2: { description: 'Partly cloudy', icon: 'partly-cloudy' },
+  3: { description: 'Overcast', icon: 'cloudy' },
+  45: { description: 'Fog', icon: 'cloudy' },
+  48: { description: 'Depositing rime fog', icon: 'cloudy' },
+  51: { description: 'Light drizzle', icon: 'rainy' },
+  53: { description: 'Moderate drizzle', icon: 'rainy' },
+  55: { description: 'Dense drizzle', icon: 'rainy' },
+  61: { description: 'Slight rain', icon: 'rainy' },
+  63: { description: 'Moderate rain', icon: 'rainy' },
+  65: { description: 'Heavy rain', icon: 'rainy' },
+  71: { description: 'Slight snow', icon: 'snowy' },
+  73: { description: 'Moderate snow', icon: 'snowy' },
+  75: { description: 'Heavy snow', icon: 'snowy' },
+  80: { description: 'Slight rain showers', icon: 'rainy' },
+  81: { description: 'Moderate rain showers', icon: 'rainy' },
+  82: { description: 'Violent rain showers', icon: 'rainy' },
+  95: { description: 'Thunderstorm', icon: 'thunderstorm' },
+  96: { description: 'Thunderstorm with slight hail', icon: 'thunderstorm' },
+  99: { description: 'Thunderstorm with heavy hail', icon: 'thunderstorm' },
+};
+
+export class WeatherService {
+  private static readonly BASE_URL = 'https://api.open-meteo.com/v1';
+  private static readonly GEOCODING_URL = 'https://geocoding-api.open-meteo.com/v1';
+
+  static async searchLocations(query: string): Promise<LocationData[]> {
+    if (!query.trim()) return [];
+
+    try {
+      const response = await fetch(
+        `${this.GEOCODING_URL}/search?name=${encodeURIComponent(query)}&count=10&language=en&format=json`,
+      );
+
+      if (!response.ok) {
+        throw new Error(`Geocoding API error: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.results || [];
+    } catch (error) {
+      console.error('Error searching locations:', error);
+      return [];
+    }
+  }
+
+  static async getCurrentWeather(latitude: number, longitude: number): Promise<WeatherData> {
+    try {
+      const params = new URLSearchParams({
+        latitude: latitude.toString(),
+        longitude: longitude.toString(),
+        current: 'temperature_2m,relative_humidity_2m,wind_speed_10m,wind_direction_10m,weather_code',
+        hourly: 'temperature_2m,relative_humidity_2m,wind_speed_10m,precipitation_probability,weather_code',
+        daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,wind_speed_10m_max,weather_code',
+        timezone: 'auto',
+        forecast_days: '7',
+      });
+
+      const response = await fetch(`${this.BASE_URL}/forecast?${params}`);
+
+      if (!response.ok) {
+        throw new Error(`Weather API error: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error('Error fetching weather data:', error);
+      throw error;
+    }
+  }
+
+  static getWeatherDescription(code: number): string {
+    return WEATHER_CODES[code]?.description || 'Unknown';
+  }
+
+  static getWeatherIcon(code: number): string {
+    return WEATHER_CODES[code]?.icon || 'cloudy';
+  }
+
+  // Default locations for quick access
+  static getDefaultLocations(): LocationData[] {
+    return [
+      { name: 'New York', latitude: 40.7128, longitude: -74.006, country: 'United States' },
+      { name: 'London', latitude: 51.5074, longitude: -0.1278, country: 'United Kingdom' },
+      { name: 'Tokyo', latitude: 35.6762, longitude: 139.6503, country: 'Japan' },
+      { name: 'Sydney', latitude: -33.8688, longitude: 151.2093, country: 'Australia' },
+      { name: 'Paris', latitude: 48.8566, longitude: 2.3522, country: 'France' },
+      { name: 'Berlin', latitude: 52.52, longitude: 13.405, country: 'Germany' },
+    ];
+  }
+}


### PR DESCRIPTION
This pull request adds a new weather dashboard demo to the application.

Changes include:

- Added weather dashboard entry to the demos list in index.tsx
- Created new weather dashboard page with main app component
- Implemented current weather display component showing temperature, humidity, wind speed and direction
- Added forecast chart component for hourly weather visualization
- Created daily forecast table with 7-day weather predictions
- Implemented location search functionality with autocomplete
- Added weather API service using Open Meteo API for data fetching
- Included weather code mappings for condition descriptions
- Provided default popular locations for quick access
- Added proper error handling and loading states throughout the dashboard

The dashboard displays real-time weather data including current conditions, hourly forecasts, and daily forecasts for searched or selected locations.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/quantum-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->
<!--<branchName>quantum-garden</branchName>-->