### PR TITLE
Add weather dashboard with Open Meteo API integration

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,6 +30,7 @@ const demos = [
     category: 'Dashboards',
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
+  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather data powered by Open Meteo API.', category: 'Dashboards' },
   {
     route: '/delete-one-click',
     title: 'One-click Delete',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,12 @@ const demos = [
     category: 'Dashboards',
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
-  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather data powered by Open Meteo API.', category: 'Dashboards' },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather data powered by Open Meteo API.',
+    category: 'Dashboards',
+  },
   {
     route: '/delete-one-click',
     title: 'One-click Delete',

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { WeatherContent } from './components/weather-content';
+import { WeatherHeader, WeatherMainInfo } from './components/weather-header';
+import { WeatherSideNavigation } from './components/weather-side-navigation';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherMainInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <WeatherHeader actions={<Button variant="primary">Add location</Button>} />
+            <WeatherContent />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+        navigation={<WeatherSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/weather-dashboard/components/current-weather-display.tsx
+++ b/src/pages/weather-dashboard/components/current-weather-display.tsx
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+interface WeatherData {
+  current: {
+    time: string;
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    wind_speed_10m: number;
+    weather_code: number;
+  };
+}
+
+interface CurrentWeatherDisplayProps {
+  weatherData: WeatherData;
+  getWeatherDescription: (code: number) => { description: string; icon: string };
+  formatTime: (dateString: string) => string;
+}
+
+export function CurrentWeatherDisplay({ weatherData, getWeatherDescription, formatTime }: CurrentWeatherDisplayProps) {
+  return (
+    <ColumnLayout columns={4} variant="text-grid">
+      <SpaceBetween size="xs">
+        <Box variant="awsui-key-label">Temperature</Box>
+        <Box fontSize="display-l" fontWeight="bold">
+          {Math.round(weatherData.current.temperature_2m)}°C
+        </Box>
+        <Box variant="small" color="text-status-info">
+          {getWeatherDescription(weatherData.current.weather_code).icon}{' '}
+          {getWeatherDescription(weatherData.current.weather_code).description}
+        </Box>
+      </SpaceBetween>
+
+      <SpaceBetween size="xs">
+        <Box variant="awsui-key-label">Humidity</Box>
+        <Box fontSize="heading-l" fontWeight="bold">
+          {weatherData.current.relative_humidity_2m}%
+        </Box>
+      </SpaceBetween>
+
+      <SpaceBetween size="xs">
+        <Box variant="awsui-key-label">Wind Speed</Box>
+        <Box fontSize="heading-l" fontWeight="bold">
+          {Math.round(weatherData.current.wind_speed_10m)} km/h
+        </Box>
+      </SpaceBetween>
+
+      <SpaceBetween size="xs">
+        <Box variant="awsui-key-label">Last Updated</Box>
+        <Box fontSize="heading-s">{formatTime(weatherData.current.time)}</Box>
+        <StatusIndicator type="success">Live</StatusIndicator>
+      </SpaceBetween>
+    </ColumnLayout>
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-content.tsx
+++ b/src/pages/weather-dashboard/components/weather-content.tsx
@@ -164,38 +164,11 @@ export function WeatherContent() {
             </Box>
           </Box>
         ) : weatherData ? (
-          <ColumnLayout columns={4} variant="text-grid">
-            <SpaceBetween size="xs">
-              <Box variant="awsui-key-label">Temperature</Box>
-              <Box fontSize="display-l" fontWeight="bold">
-                {Math.round(weatherData.current.temperature_2m)}°C
-              </Box>
-              <Box variant="small" color="text-status-info">
-                {getWeatherDescription(weatherData.current.weather_code).icon}{' '}
-                {getWeatherDescription(weatherData.current.weather_code).description}
-              </Box>
-            </SpaceBetween>
-
-            <SpaceBetween size="xs">
-              <Box variant="awsui-key-label">Humidity</Box>
-              <Box fontSize="heading-l" fontWeight="bold">
-                {weatherData.current.relative_humidity_2m}%
-              </Box>
-            </SpaceBetween>
-
-            <SpaceBetween size="xs">
-              <Box variant="awsui-key-label">Wind Speed</Box>
-              <Box fontSize="heading-l" fontWeight="bold">
-                {Math.round(weatherData.current.wind_speed_10m)} km/h
-              </Box>
-            </SpaceBetween>
-
-            <SpaceBetween size="xs">
-              <Box variant="awsui-key-label">Last Updated</Box>
-              <Box fontSize="heading-s">{formatTime(weatherData.current.time)}</Box>
-              <StatusIndicator type="success">Live</StatusIndicator>
-            </SpaceBetween>
-          </ColumnLayout>
+          <CurrentWeatherDisplay
+            weatherData={weatherData}
+            getWeatherDescription={getWeatherDescription}
+            formatTime={formatTime}
+          />
         ) : null}
       </Container>
 

--- a/src/pages/weather-dashboard/components/weather-content.tsx
+++ b/src/pages/weather-dashboard/components/weather-content.tsx
@@ -15,6 +15,8 @@ import Spinner from '@cloudscape-design/components/spinner';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 import Select from '@cloudscape-design/components/select';
 
+import { CurrentWeatherDisplay } from './current-weather-display';
+
 interface WeatherData {
   current: {
     time: string;

--- a/src/pages/weather-dashboard/components/weather-content.tsx
+++ b/src/pages/weather-dashboard/components/weather-content.tsx
@@ -15,7 +15,6 @@ import Spinner from '@cloudscape-design/components/spinner';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 import Select from '@cloudscape-design/components/select';
 
-
 interface WeatherData {
   current: {
     time: string;
@@ -47,11 +46,11 @@ interface Location {
 }
 
 const LOCATIONS: Location[] = [
-  { label: 'New York, NY', value: 'nyc', latitude: 40.7128, longitude: -74.0060 },
+  { label: 'New York, NY', value: 'nyc', latitude: 40.7128, longitude: -74.006 },
   { label: 'London, UK', value: 'london', latitude: 51.5074, longitude: -0.1278 },
   { label: 'Tokyo, Japan', value: 'tokyo', latitude: 35.6762, longitude: 139.6503 },
   { label: 'Sydney, Australia', value: 'sydney', latitude: -33.8688, longitude: 151.2093 },
-  { label: 'Berlin, Germany', value: 'berlin', latitude: 52.5200, longitude: 13.4050 },
+  { label: 'Berlin, Germany', value: 'berlin', latitude: 52.52, longitude: 13.405 },
 ];
 
 const getWeatherDescription = (code: number) => {
@@ -85,15 +84,15 @@ export function WeatherContent() {
   const fetchWeatherData = async (location: Location) => {
     setLoading(true);
     setError(null);
-    
+
     try {
       const url = `https://api.open-meteo.com/v1/forecast?latitude=${location.latitude}&longitude=${location.longitude}&current=temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code&hourly=temperature_2m,precipitation_probability,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&timezone=auto&forecast_days=7`;
-      
+
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch weather data');
       }
-      
+
       const data = await response.json();
       setWeatherData(data);
     } catch (err) {
@@ -158,7 +157,9 @@ export function WeatherContent() {
         {loading ? (
           <Box textAlign="center" padding="l">
             <Spinner size="large" />
-            <Box variant="p" margin={{ top: 's' }}>Loading weather data...</Box>
+            <Box variant="p" margin={{ top: 's' }}>
+              Loading weather data...
+            </Box>
           </Box>
         ) : weatherData ? (
           <ColumnLayout columns={4} variant="text-grid">
@@ -189,9 +190,7 @@ export function WeatherContent() {
 
             <SpaceBetween size="xs">
               <Box variant="awsui-key-label">Last Updated</Box>
-              <Box fontSize="heading-s">
-                {formatTime(weatherData.current.time)}
-              </Box>
+              <Box fontSize="heading-s">{formatTime(weatherData.current.time)}</Box>
               <StatusIndicator type="success">Live</StatusIndicator>
             </SpaceBetween>
           </ColumnLayout>
@@ -248,9 +247,7 @@ export function WeatherContent() {
                       <Box>
                         <SpaceBetween direction="horizontal" size="xs">
                           <span>{weather.icon}</span>
-                          <Box fontWeight="bold">
-                            {Math.round(weatherData.daily.temperature_2m_max[index])}°
-                          </Box>
+                          <Box fontWeight="bold">{Math.round(weatherData.daily.temperature_2m_max[index])}°</Box>
                           <Box color="text-status-inactive">
                             {Math.round(weatherData.daily.temperature_2m_min[index])}°
                           </Box>

--- a/src/pages/weather-dashboard/components/weather-content.tsx
+++ b/src/pages/weather-dashboard/components/weather-content.tsx
@@ -14,7 +14,7 @@ import Alert from '@cloudscape-design/components/alert';
 import Spinner from '@cloudscape-design/components/spinner';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 import Select from '@cloudscape-design/components/select';
-import ValueWithLabel from '@cloudscape-design/components/value-with-label';
+
 
 interface WeatherData {
   current: {

--- a/src/pages/weather-dashboard/components/weather-content.tsx
+++ b/src/pages/weather-dashboard/components/weather-content.tsx
@@ -1,0 +1,271 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useEffect } from 'react';
+
+import Grid from '@cloudscape-design/components/grid';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import Button from '@cloudscape-design/components/button';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Alert from '@cloudscape-design/components/alert';
+import Spinner from '@cloudscape-design/components/spinner';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Select from '@cloudscape-design/components/select';
+import ValueWithLabel from '@cloudscape-design/components/value-with-label';
+
+interface WeatherData {
+  current: {
+    time: string;
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    wind_speed_10m: number;
+    weather_code: number;
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    precipitation_probability: number[];
+    wind_speed_10m: number[];
+  };
+  daily: {
+    time: string[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_sum: number[];
+    weather_code: number[];
+  };
+}
+
+interface Location {
+  label: string;
+  value: string;
+  latitude: number;
+  longitude: number;
+}
+
+const LOCATIONS: Location[] = [
+  { label: 'New York, NY', value: 'nyc', latitude: 40.7128, longitude: -74.0060 },
+  { label: 'London, UK', value: 'london', latitude: 51.5074, longitude: -0.1278 },
+  { label: 'Tokyo, Japan', value: 'tokyo', latitude: 35.6762, longitude: 139.6503 },
+  { label: 'Sydney, Australia', value: 'sydney', latitude: -33.8688, longitude: 151.2093 },
+  { label: 'Berlin, Germany', value: 'berlin', latitude: 52.5200, longitude: 13.4050 },
+];
+
+const getWeatherDescription = (code: number) => {
+  const weatherCodes: { [key: number]: { description: string; icon: string } } = {
+    0: { description: 'Clear sky', icon: '☀️' },
+    1: { description: 'Mainly clear', icon: '🌤️' },
+    2: { description: 'Partly cloudy', icon: '⛅' },
+    3: { description: 'Overcast', icon: '☁️' },
+    45: { description: 'Fog', icon: '🌫️' },
+    48: { description: 'Depositing rime fog', icon: '🌫️' },
+    51: { description: 'Light drizzle', icon: '🌦️' },
+    53: { description: 'Moderate drizzle', icon: '🌦️' },
+    55: { description: 'Dense drizzle', icon: '🌧️' },
+    61: { description: 'Slight rain', icon: '🌧️' },
+    63: { description: 'Moderate rain', icon: '🌧️' },
+    65: { description: 'Heavy rain', icon: '⛈️' },
+    71: { description: 'Slight snow', icon: '🌨️' },
+    73: { description: 'Moderate snow', icon: '❄️' },
+    75: { description: 'Heavy snow', icon: '❄️' },
+    95: { description: 'Thunderstorm', icon: '⛈️' },
+  };
+  return weatherCodes[code] || { description: 'Unknown', icon: '❓' };
+};
+
+export function WeatherContent() {
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [selectedLocation, setSelectedLocation] = useState<Location>(LOCATIONS[0]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchWeatherData = async (location: Location) => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const url = `https://api.open-meteo.com/v1/forecast?latitude=${location.latitude}&longitude=${location.longitude}&current=temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code&hourly=temperature_2m,precipitation_probability,wind_speed_10m&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code&timezone=auto&forecast_days=7`;
+      
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('Failed to fetch weather data');
+      }
+      
+      const data = await response.json();
+      setWeatherData(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWeatherData(selectedLocation);
+  }, [selectedLocation]);
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const formatTime = (dateString: string) => {
+    return new Date(dateString).toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  if (error) {
+    return (
+      <Alert type="error" header="Failed to load weather data">
+        {error}
+        <Box margin={{ top: 's' }}>
+          <Button onClick={() => fetchWeatherData(selectedLocation)}>Retry</Button>
+        </Box>
+      </Alert>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Container
+        header={
+          <Header
+            variant="h2"
+            actions={
+              <Select
+                selectedOption={{ label: selectedLocation.label, value: selectedLocation.value }}
+                onChange={({ detail }) => {
+                  const location = LOCATIONS.find(loc => loc.value === detail.selectedOption.value);
+                  if (location) setSelectedLocation(location);
+                }}
+                options={LOCATIONS.map(loc => ({ label: loc.label, value: loc.value }))}
+                placeholder="Select location"
+              />
+            }
+          >
+            Current Weather
+          </Header>
+        }
+      >
+        {loading ? (
+          <Box textAlign="center" padding="l">
+            <Spinner size="large" />
+            <Box variant="p" margin={{ top: 's' }}>Loading weather data...</Box>
+          </Box>
+        ) : weatherData ? (
+          <ColumnLayout columns={4} variant="text-grid">
+            <ValueWithLabel label="Temperature">
+              <Box fontSize="display-l" fontWeight="bold">
+                {Math.round(weatherData.current.temperature_2m)}°C
+              </Box>
+              <Box variant="small" color="text-status-info">
+                {getWeatherDescription(weatherData.current.weather_code).icon}{' '}
+                {getWeatherDescription(weatherData.current.weather_code).description}
+              </Box>
+            </ValueWithLabel>
+            
+            <ValueWithLabel label="Humidity">
+              <Box fontSize="heading-l" fontWeight="bold">
+                {weatherData.current.relative_humidity_2m}%
+              </Box>
+            </ValueWithLabel>
+            
+            <ValueWithLabel label="Wind Speed">
+              <Box fontSize="heading-l" fontWeight="bold">
+                {Math.round(weatherData.current.wind_speed_10m)} km/h
+              </Box>
+            </ValueWithLabel>
+            
+            <ValueWithLabel label="Last Updated">
+              <Box fontSize="heading-s">
+                {formatTime(weatherData.current.time)}
+              </Box>
+              <StatusIndicator type="success">Live</StatusIndicator>
+            </ValueWithLabel>
+          </ColumnLayout>
+        ) : null}
+      </Container>
+
+      <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+        <Container
+          header={
+            <Header variant="h2" counter={weatherData?.hourly.time.slice(0, 24).length.toString()}>
+              24-Hour Forecast
+            </Header>
+          }
+        >
+          {loading ? (
+            <Box textAlign="center" padding="l">
+              <Spinner />
+            </Box>
+          ) : weatherData ? (
+            <SpaceBetween size="s">
+              {weatherData.hourly.time.slice(0, 24).map((time, index) => (
+                <Box key={time} padding={{ vertical: 'xs', horizontal: 's' }}>
+                  <ColumnLayout columns={4} variant="text-grid">
+                    <Box variant="small">{formatTime(time)}</Box>
+                    <Box fontWeight="bold">{Math.round(weatherData.hourly.temperature_2m[index])}°C</Box>
+                    <Box variant="small">{weatherData.hourly.precipitation_probability[index]}% rain</Box>
+                    <Box variant="small">{Math.round(weatherData.hourly.wind_speed_10m[index])} km/h</Box>
+                  </ColumnLayout>
+                </Box>
+              ))}
+            </SpaceBetween>
+          ) : null}
+        </Container>
+
+        <Container
+          header={
+            <Header variant="h2" counter={weatherData?.daily.time.length.toString()}>
+              7-Day Forecast
+            </Header>
+          }
+        >
+          {loading ? (
+            <Box textAlign="center" padding="l">
+              <Spinner />
+            </Box>
+          ) : weatherData ? (
+            <SpaceBetween size="s">
+              {weatherData.daily.time.map((date, index) => {
+                const weather = getWeatherDescription(weatherData.daily.weather_code[index]);
+                return (
+                  <Box key={date} padding={{ vertical: 's', horizontal: 's' }}>
+                    <ColumnLayout columns={4} variant="text-grid">
+                      <Box fontWeight="bold">{formatDate(date)}</Box>
+                      <Box>
+                        <SpaceBetween direction="horizontal" size="xs">
+                          <span>{weather.icon}</span>
+                          <Box fontWeight="bold">
+                            {Math.round(weatherData.daily.temperature_2m_max[index])}°
+                          </Box>
+                          <Box color="text-status-inactive">
+                            {Math.round(weatherData.daily.temperature_2m_min[index])}°
+                          </Box>
+                        </SpaceBetween>
+                      </Box>
+                      <Box variant="small">{weather.description}</Box>
+                      <Box variant="small">
+                        {weatherData.daily.precipitation_sum[index] > 0 && (
+                          <Badge color="blue">{weatherData.daily.precipitation_sum[index].toFixed(1)}mm</Badge>
+                        )}
+                      </Box>
+                    </ColumnLayout>
+                  </Box>
+                );
+              })}
+            </SpaceBetween>
+          ) : null}
+        </Container>
+      </Grid>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-content.tsx
+++ b/src/pages/weather-dashboard/components/weather-content.tsx
@@ -162,7 +162,8 @@ export function WeatherContent() {
           </Box>
         ) : weatherData ? (
           <ColumnLayout columns={4} variant="text-grid">
-            <ValueWithLabel label="Temperature">
+            <SpaceBetween size="xs">
+              <Box variant="awsui-key-label">Temperature</Box>
               <Box fontSize="display-l" fontWeight="bold">
                 {Math.round(weatherData.current.temperature_2m)}°C
               </Box>
@@ -170,26 +171,29 @@ export function WeatherContent() {
                 {getWeatherDescription(weatherData.current.weather_code).icon}{' '}
                 {getWeatherDescription(weatherData.current.weather_code).description}
               </Box>
-            </ValueWithLabel>
-            
-            <ValueWithLabel label="Humidity">
+            </SpaceBetween>
+
+            <SpaceBetween size="xs">
+              <Box variant="awsui-key-label">Humidity</Box>
               <Box fontSize="heading-l" fontWeight="bold">
                 {weatherData.current.relative_humidity_2m}%
               </Box>
-            </ValueWithLabel>
-            
-            <ValueWithLabel label="Wind Speed">
+            </SpaceBetween>
+
+            <SpaceBetween size="xs">
+              <Box variant="awsui-key-label">Wind Speed</Box>
               <Box fontSize="heading-l" fontWeight="bold">
                 {Math.round(weatherData.current.wind_speed_10m)} km/h
               </Box>
-            </ValueWithLabel>
-            
-            <ValueWithLabel label="Last Updated">
+            </SpaceBetween>
+
+            <SpaceBetween size="xs">
+              <Box variant="awsui-key-label">Last Updated</Box>
               <Box fontSize="heading-s">
                 {formatTime(weatherData.current.time)}
               </Box>
               <StatusIndicator type="success">Live</StatusIndicator>
-            </ValueWithLabel>
+            </SpaceBetween>
           </ColumnLayout>
         ) : null}
       </Container>

--- a/src/pages/weather-dashboard/components/weather-header.tsx
+++ b/src/pages/weather-dashboard/components/weather-header.tsx
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+export function WeatherHeader({ actions }: { actions?: React.ReactNode }) {
+  return (
+    <Header variant="h1" actions={actions}>
+      Weather Dashboard
+    </Header>
+  );
+}
+
+export function WeatherMainInfo() {
+  return (
+    <SpaceBetween size="l">
+      <div>
+        <Box variant="h2">Weather Dashboard</Box>
+        <Box variant="p">Real-time weather data powered by Open Meteo API</Box>
+      </div>
+      <div>
+        <Box variant="h3">Features</Box>
+        <SpaceBetween size="s">
+          <Box variant="p">• Current weather conditions</Box>
+          <Box variant="p">• 7-day weather forecast</Box>
+          <Box variant="p">• Multiple location support</Box>
+          <Box variant="p">• Interactive weather charts</Box>
+        </SpaceBetween>
+      </div>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-side-navigation.tsx
+++ b/src/pages/weather-dashboard/components/weather-side-navigation.tsx
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation from '@cloudscape-design/components/side-navigation';
+
+export function WeatherSideNavigation() {
+  return (
+    <SideNavigation
+      activeHref="#/"
+      header={{ href: "#/", text: "Weather" }}
+      items={[
+        { type: "link", text: "Current Weather", href: "#/current" },
+        { type: "link", text: "Forecast", href: "#/forecast" },
+        { type: "link", text: "Historical Data", href: "#/historical" },
+        { type: "divider" },
+        { type: "link", text: "Settings", href: "#/settings" },
+        { type: "link", text: "About API", href: "#/about", external: true },
+      ]}
+    />
+  );
+}

--- a/src/pages/weather-dashboard/components/weather-side-navigation.tsx
+++ b/src/pages/weather-dashboard/components/weather-side-navigation.tsx
@@ -8,14 +8,14 @@ export function WeatherSideNavigation() {
   return (
     <SideNavigation
       activeHref="#/"
-      header={{ href: "#/", text: "Weather" }}
+      header={{ href: '#/', text: 'Weather' }}
       items={[
-        { type: "link", text: "Current Weather", href: "#/current" },
-        { type: "link", text: "Forecast", href: "#/forecast" },
-        { type: "link", text: "Historical Data", href: "#/historical" },
-        { type: "divider" },
-        { type: "link", text: "Settings", href: "#/settings" },
-        { type: "link", text: "About API", href: "#/about", external: true },
+        { type: 'link', text: 'Current Weather', href: '#/current' },
+        { type: 'link', text: 'Forecast', href: '#/forecast' },
+        { type: 'link', text: 'Historical Data', href: '#/historical' },
+        { type: 'divider' },
+        { type: 'link', text: 'Settings', href: '#/settings' },
+        { type: 'link', text: 'About API', href: '#/about', external: true },
       ]}
     />
   );

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}


### PR DESCRIPTION
## Purpose

The user requested a new weather dashboard powered by the Open Meteo API to provide real-time weather data and forecasting capabilities within the application.

## Code changes

- **Added weather dashboard route**: Registered new `/weather-dashboard` route in the main demos list with appropriate metadata
- **Created main dashboard app**: Implemented `app.tsx` with layout structure, navigation, and help panel integration
- **Built weather content component**: Developed comprehensive weather display with:
  - Current weather conditions (temperature, humidity, wind speed)
  - 24-hour hourly forecast
  - 7-day daily forecast
  - Location selector for multiple cities
  - Weather code interpretation with icons and descriptions
- **Added header component**: Created weather-specific header with actions and help panel content
- **Implemented side navigation**: Built navigation menu with weather-related sections
- **Added main index file**: Created entry point that imports and renders the weather dashboard app

The dashboard integrates with the Open Meteo API to fetch real-time weather data for multiple predefined locations including New York, London, Tokyo, Sydney, and Berlin.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/vibe-den)

👀 [Preview Link](https://98bf2453a9fe441eb6778cbc07f519aa-vibe-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->
<!--<branchName>vibe-den</branchName>-->