### PR TITLE
Add weather dashboard with Open-Meteo API integration

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,12 @@ const demos = [
     category: 'Dashboards',
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
-  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather dashboard using Open-Meteo API.', category: 'Dashboards' },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather dashboard using Open-Meteo API.',
+    category: 'Dashboards',
+  },
   {
     route: '/delete-one-click',
     title: 'One-click Delete',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,6 +30,7 @@ const demos = [
     category: 'Dashboards',
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
+  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather dashboard using Open-Meteo API.', category: 'Dashboards' },
   {
     route: '/delete-one-click',
     title: 'One-click Delete',

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { Content } from './components/content';
+import { WeatherDashboardHeader, WeatherDashboardMainInfo } from './components/header';
+import { WeatherDashboardSideNavigation } from './components/side-navigation';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherDashboardMainInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <WeatherDashboardHeader actions={<Button variant="primary">Set Location</Button>} />
+            <Content />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/weather-dashboard' }]} />}
+        navigation={<WeatherDashboardSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -11,6 +11,7 @@ import { CustomAppLayout } from '../commons/common-components';
 import { Content } from './components/content';
 import { WeatherDashboardHeader, WeatherDashboardMainInfo } from './components/header';
 import { WeatherDashboardSideNavigation } from './components/side-navigation';
+import { TemperatureUnitProvider } from './context/temperature-unit-context';
 
 import '@cloudscape-design/global-styles/dark-mode-utils.css';
 
@@ -26,22 +27,24 @@ export function App() {
   };
 
   return (
-    <HelpPanelProvider value={handleToolsContentChange}>
-      <CustomAppLayout
-        ref={appLayout}
-        content={
-          <SpaceBetween size="m">
-            <WeatherDashboardHeader actions={<Button variant="primary">Set Location</Button>} />
-            <Content />
-          </SpaceBetween>
-        }
-        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/weather-dashboard' }]} />}
-        navigation={<WeatherDashboardSideNavigation />}
-        tools={toolsContent}
-        toolsOpen={toolsOpen}
-        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
-        notifications={<Notifications />}
-      />
-    </HelpPanelProvider>
+    <TemperatureUnitProvider>
+      <HelpPanelProvider value={handleToolsContentChange}>
+        <CustomAppLayout
+          ref={appLayout}
+          content={
+            <SpaceBetween size="m">
+              <WeatherDashboardHeader actions={<Button variant="primary">Set Location</Button>} />
+              <Content />
+            </SpaceBetween>
+          }
+          breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/weather-dashboard' }]} />}
+          navigation={<WeatherDashboardSideNavigation />}
+          tools={toolsContent}
+          toolsOpen={toolsOpen}
+          onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+          notifications={<Notifications />}
+        />
+      </HelpPanelProvider>
+    </TemperatureUnitProvider>
   );
 }

--- a/src/pages/weather-dashboard/components/content.tsx
+++ b/src/pages/weather-dashboard/components/content.tsx
@@ -8,12 +8,14 @@ import Alert from '@cloudscape-design/components/alert';
 import Spinner from '@cloudscape-design/components/spinner';
 
 import { weatherAPI, WeatherData, DEFAULT_LOCATION } from '../services/weather-api';
-import { CurrentWeatherWidget } from '../widgets/current-weather-widget';
-import { HourlyForecastWidget } from '../widgets/hourly-forecast-widget';
-import { DailyForecastWidget } from '../widgets/daily-forecast-widget';
-import { TemperatureChartWidget } from '../widgets/temperature-chart-widget';
-import { PrecipitationWidget } from '../widgets/precipitation-widget';
-import { WindWidget } from '../widgets/wind-widget';
+import {
+  CurrentWeatherWidget,
+  HourlyForecastWidget,
+  DailyForecastWidget,
+  TemperatureChartWidget,
+  PrecipitationWidget,
+  WindWidget,
+} from '../widgets';
 
 export function Content() {
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null);

--- a/src/pages/weather-dashboard/components/content.tsx
+++ b/src/pages/weather-dashboard/components/content.tsx
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useEffect, useState } from 'react';
+
+import Grid from '@cloudscape-design/components/grid';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Alert from '@cloudscape-design/components/alert';
+import Spinner from '@cloudscape-design/components/spinner';
+
+import { weatherAPI, WeatherData, DEFAULT_LOCATION } from '../services/weather-api';
+import { CurrentWeatherWidget } from '../widgets/current-weather-widget';
+import { HourlyForecastWidget } from '../widgets/hourly-forecast-widget';
+import { DailyForecastWidget } from '../widgets/daily-forecast-widget';
+import { TemperatureChartWidget } from '../widgets/temperature-chart-widget';
+import { PrecipitationWidget } from '../widgets/precipitation-widget';
+import { WindWidget } from '../widgets/wind-widget';
+
+export function Content() {
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchWeatherData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await weatherAPI.getCompleteWeatherData(DEFAULT_LOCATION);
+        setWeatherData(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch weather data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchWeatherData();
+    
+    // Refresh data every 10 minutes
+    const interval = setInterval(fetchWeatherData, 10 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: 'center', padding: '60px' }}>
+        <SpaceBetween size="m">
+          <Spinner size="large" />
+          <div>Loading weather data...</div>
+        </SpaceBetween>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert type="error" header="Failed to load weather data">
+        {error}
+      </Alert>
+    );
+  }
+
+  if (!weatherData) {
+    return (
+      <Alert type="info" header="No weather data available">
+        Please check your connection and try again.
+      </Alert>
+    );
+  }
+
+  return (
+    <Grid
+      gridDefinition={[
+        { colspan: { l: 4, m: 6, default: 12 } },
+        { colspan: { l: 4, m: 6, default: 12 } },
+        { colspan: { l: 4, m: 12, default: 12 } },
+        { colspan: { l: 8, m: 12, default: 12 } },
+        { colspan: { l: 4, m: 12, default: 12 } },
+        { colspan: { l: 6, m: 6, default: 12 } },
+        { colspan: { l: 6, m: 6, default: 12 } },
+      ]}
+    >
+      <CurrentWeatherWidget data={weatherData.current} location={weatherData.location} />
+      <TemperatureChartWidget data={weatherData.hourly} />
+      <WindWidget current={weatherData.current} hourly={weatherData.hourly} />
+      <HourlyForecastWidget data={weatherData.hourly} />
+      <DailyForecastWidget data={weatherData.daily} />
+      <PrecipitationWidget data={weatherData.hourly} />
+    </Grid>
+  );
+}

--- a/src/pages/weather-dashboard/components/content.tsx
+++ b/src/pages/weather-dashboard/components/content.tsx
@@ -37,7 +37,7 @@ export function Content() {
     };
 
     fetchWeatherData();
-    
+
     // Refresh data every 10 minutes
     const interval = setInterval(fetchWeatherData, 10 * 60 * 1000);
     return () => clearInterval(interval);

--- a/src/pages/weather-dashboard/components/header.tsx
+++ b/src/pages/weather-dashboard/components/header.tsx
@@ -24,12 +24,12 @@ export function WeatherDashboardMainInfo() {
       }
     >
       <p>
-        This weather dashboard displays real-time weather information and forecasts using the Open-Meteo API. 
-        It provides current conditions, hourly forecasts, and daily weather predictions for any location worldwide.
+        This weather dashboard displays real-time weather information and forecasts using the Open-Meteo API. It
+        provides current conditions, hourly forecasts, and daily weather predictions for any location worldwide.
       </p>
       <p>
-        The dashboard includes temperature trends, precipitation data, weather conditions, and interactive charts 
-        to help you monitor weather patterns effectively.
+        The dashboard includes temperature trends, precipitation data, weather conditions, and interactive charts to
+        help you monitor weather patterns effectively.
       </p>
     </HelpPanel>
   );

--- a/src/pages/weather-dashboard/components/header.tsx
+++ b/src/pages/weather-dashboard/components/header.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Header from '@cloudscape-design/components/header';
+import HelpPanel from '@cloudscape-design/components/help-panel';
+
+import { ExternalLinkGroup, InfoLink, useHelpPanel } from '../../commons';
+
+export function WeatherDashboardMainInfo() {
+  return (
+    <HelpPanel
+      header={<h2>Weather Dashboard</h2>}
+      footer={
+        <ExternalLinkGroup
+          items={[
+            { href: 'https://open-meteo.com/en/docs', text: 'Open-Meteo API Documentation' },
+            { href: 'https://open-meteo.com/en/features', text: 'Weather Data Features' },
+            { href: 'https://cloudscape.design/components/', text: 'Cloudscape Components' },
+          ]}
+        />
+      }
+    >
+      <p>
+        This weather dashboard displays real-time weather information and forecasts using the Open-Meteo API. 
+        It provides current conditions, hourly forecasts, and daily weather predictions for any location worldwide.
+      </p>
+      <p>
+        The dashboard includes temperature trends, precipitation data, weather conditions, and interactive charts 
+        to help you monitor weather patterns effectively.
+      </p>
+    </HelpPanel>
+  );
+}
+
+export function WeatherDashboardHeader({ actions }: { actions: React.ReactNode }) {
+  const loadHelpPanelContent = useHelpPanel();
+  return (
+    <Header
+      variant="h1"
+      info={<InfoLink onFollow={() => loadHelpPanelContent(<WeatherDashboardMainInfo />)} />}
+      actions={actions}
+    >
+      Weather Dashboard
+    </Header>
+  );
+}

--- a/src/pages/weather-dashboard/components/header.tsx
+++ b/src/pages/weather-dashboard/components/header.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 
 import Header from '@cloudscape-design/components/header';
 import HelpPanel from '@cloudscape-design/components/help-panel';
+import SpaceBetween from '@cloudscape-design/components/space-between';
 
 import { ExternalLinkGroup, InfoLink, useHelpPanel } from '../../commons';
+import { TemperatureUnitPicker } from './temperature-unit-picker';
 
 export function WeatherDashboardMainInfo() {
   return (
@@ -39,7 +41,12 @@ export function WeatherDashboardHeader({ actions }: { actions: React.ReactNode }
     <Header
       variant="h1"
       info={<InfoLink onFollow={() => loadHelpPanelContent(<WeatherDashboardMainInfo />)} />}
-      actions={actions}
+      actions={
+        <SpaceBetween direction="horizontal" size="m">
+          <TemperatureUnitPicker />
+          {actions}
+        </SpaceBetween>
+      }
     >
       Weather Dashboard
     </Header>

--- a/src/pages/weather-dashboard/components/side-navigation.tsx
+++ b/src/pages/weather-dashboard/components/side-navigation.tsx
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation, { SideNavigationProps } from '@cloudscape-design/components/side-navigation';
+
+const navigationItems: SideNavigationProps['items'] = [
+  { type: 'link', text: 'Current Weather', href: '#/weather-dashboard' },
+  { type: 'link', text: 'Hourly Forecast', href: '#/weather-dashboard/hourly' },
+  { type: 'link', text: 'Daily Forecast', href: '#/weather-dashboard/daily' },
+  { type: 'divider' },
+  {
+    type: 'section',
+    text: 'Weather Data',
+    items: [
+      { type: 'link', text: 'Temperature', href: '#/weather-dashboard/temperature' },
+      { type: 'link', text: 'Precipitation', href: '#/weather-dashboard/precipitation' },
+      { type: 'link', text: 'Wind', href: '#/weather-dashboard/wind' },
+      { type: 'link', text: 'Atmospheric', href: '#/weather-dashboard/atmospheric' },
+    ],
+  },
+  { type: 'divider' },
+  {
+    type: 'section',
+    text: 'Settings',
+    items: [
+      { type: 'link', text: 'Location Settings', href: '#/weather-dashboard/settings' },
+      { type: 'link', text: 'Units', href: '#/weather-dashboard/units' },
+    ],
+  },
+];
+
+export function WeatherDashboardSideNavigation() {
+  return (
+    <SideNavigation
+      activeHref="#/weather-dashboard"
+      header={{ href: '#/', text: 'Weather Service' }}
+      items={navigationItems}
+    />
+  );
+}

--- a/src/pages/weather-dashboard/components/temperature-unit-picker.tsx
+++ b/src/pages/weather-dashboard/components/temperature-unit-picker.tsx
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SegmentedControl from '@cloudscape-design/components/segmented-control';
+
+import { useTemperatureUnit } from '../context/temperature-unit-context';
+
+export function TemperatureUnitPicker() {
+  const { unit, setUnit } = useTemperatureUnit();
+
+  return (
+    <SegmentedControl
+      selectedId={unit}
+      onChange={({ detail }) => setUnit(detail.selectedId as 'celsius' | 'fahrenheit')}
+      label="Temperature unit"
+      options={[
+        { id: 'celsius', text: '°C' },
+        { id: 'fahrenheit', text: '°F' },
+      ]}
+    />
+  );
+}

--- a/src/pages/weather-dashboard/context/temperature-unit-context.tsx
+++ b/src/pages/weather-dashboard/context/temperature-unit-context.tsx
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type TemperatureUnit = 'celsius' | 'fahrenheit';
+
+interface TemperatureUnitContextType {
+  unit: TemperatureUnit;
+  setUnit: (unit: TemperatureUnit) => void;
+  convertTemperature: (celsius: number) => number;
+  getUnitSymbol: () => string;
+}
+
+const TemperatureUnitContext = createContext<TemperatureUnitContextType | undefined>(undefined);
+
+export function useTemperatureUnit(): TemperatureUnitContextType {
+  const context = useContext(TemperatureUnitContext);
+  if (!context) {
+    throw new Error('useTemperatureUnit must be used within a TemperatureUnitProvider');
+  }
+  return context;
+}
+
+interface TemperatureUnitProviderProps {
+  children: ReactNode;
+}
+
+export function TemperatureUnitProvider({ children }: TemperatureUnitProviderProps) {
+  const [unit, setUnit] = useState<TemperatureUnit>('celsius');
+
+  const convertTemperature = (celsius: number): number => {
+    if (unit === 'fahrenheit') {
+      return (celsius * 9) / 5 + 32;
+    }
+    return celsius;
+  };
+
+  const getUnitSymbol = (): string => {
+    return unit === 'celsius' ? '°C' : '°F';
+  };
+
+  const value: TemperatureUnitContextType = {
+    unit,
+    setUnit,
+    convertTemperature,
+    getUnitSymbol,
+  };
+
+  return (
+    <TemperatureUnitContext.Provider value={value}>
+      {children}
+    </TemperatureUnitContext.Provider>
+  );
+}

--- a/src/pages/weather-dashboard/context/temperature-unit-context.tsx
+++ b/src/pages/weather-dashboard/context/temperature-unit-context.tsx
@@ -46,9 +46,5 @@ export function TemperatureUnitProvider({ children }: TemperatureUnitProviderPro
     getUnitSymbol,
   };
 
-  return (
-    <TemperatureUnitContext.Provider value={value}>
-      {children}
-    </TemperatureUnitContext.Provider>
-  );
+  return <TemperatureUnitContext.Provider value={value}>{children}</TemperatureUnitContext.Provider>;
 }

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/services/weather-api.ts
+++ b/src/pages/weather-dashboard/services/weather-api.ts
@@ -166,7 +166,7 @@ export class WeatherAPIService {
     const [current, hourly, daily] = await Promise.all([
       this.getCurrentWeather(location),
       this.getHourlyForecast(location, 24),
-      this.getDailyForecast(location, 7),
+      this.getDailyForecast(location, 8),
     ]);
 
     return {

--- a/src/pages/weather-dashboard/services/weather-api.ts
+++ b/src/pages/weather-dashboard/services/weather-api.ts
@@ -1,0 +1,185 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface WeatherLocation {
+  latitude: number;
+  longitude: number;
+  name: string;
+}
+
+export interface CurrentWeather {
+  time: string;
+  temperature: number;
+  weatherCode: number;
+  windSpeed: number;
+  windDirection: number;
+  humidity: number;
+  pressure: number;
+  precipitation: number;
+}
+
+export interface HourlyWeather {
+  time: string[];
+  temperature: number[];
+  weatherCode: number[];
+  precipitation: number[];
+  windSpeed: number[];
+  humidity: number[];
+}
+
+export interface DailyWeather {
+  time: string[];
+  temperatureMax: number[];
+  temperatureMin: number[];
+  weatherCode: number[];
+  precipitationSum: number[];
+  windSpeedMax: number[];
+  sunrise: string[];
+  sunset: string[];
+}
+
+export interface WeatherData {
+  current: CurrentWeather;
+  hourly: HourlyWeather;
+  daily: DailyWeather;
+  location: WeatherLocation;
+}
+
+// Weather code descriptions
+export const WEATHER_CODES: Record<number, { description: string; icon: string }> = {
+  0: { description: 'Clear sky', icon: '☀️' },
+  1: { description: 'Mainly clear', icon: '🌤️' },
+  2: { description: 'Partly cloudy', icon: '⛅' },
+  3: { description: 'Overcast', icon: '☁️' },
+  45: { description: 'Fog', icon: '🌫️' },
+  48: { description: 'Depositing rime fog', icon: '🌫️' },
+  51: { description: 'Light drizzle', icon: '🌦️' },
+  53: { description: 'Moderate drizzle', icon: '🌦️' },
+  55: { description: 'Dense drizzle', icon: '🌧️' },
+  56: { description: 'Light freezing drizzle', icon: '🌧️' },
+  57: { description: 'Dense freezing drizzle', icon: '🌧️' },
+  61: { description: 'Slight rain', icon: '🌧️' },
+  63: { description: 'Moderate rain', icon: '🌧️' },
+  65: { description: 'Heavy rain', icon: '🌧️' },
+  66: { description: 'Light freezing rain', icon: '🌨️' },
+  67: { description: 'Heavy freezing rain', icon: '🌨️' },
+  71: { description: 'Slight snow fall', icon: '🌨️' },
+  73: { description: 'Moderate snow fall', icon: '❄️' },
+  75: { description: 'Heavy snow fall', icon: '❄️' },
+  77: { description: 'Snow grains', icon: '❄️' },
+  80: { description: 'Slight rain showers', icon: '🌦️' },
+  81: { description: 'Moderate rain showers', icon: '🌧️' },
+  82: { description: 'Violent rain showers', icon: '🌧️' },
+  85: { description: 'Slight snow showers', icon: '🌨️' },
+  86: { description: 'Heavy snow showers', icon: '❄️' },
+  95: { description: 'Thunderstorm', icon: '⛈️' },
+  96: { description: 'Thunderstorm with slight hail', icon: '⛈️' },
+  99: { description: 'Thunderstorm with heavy hail', icon: '⛈️' },
+};
+
+// Default location (New York City)
+export const DEFAULT_LOCATION: WeatherLocation = {
+  latitude: 40.7128,
+  longitude: -74.0060,
+  name: 'New York City',
+};
+
+export class WeatherAPIService {
+  private baseUrl = 'https://api.open-meteo.com/v1/forecast';
+
+  async getCurrentWeather(location: WeatherLocation = DEFAULT_LOCATION): Promise<CurrentWeather> {
+    const url = new URL(this.baseUrl);
+    url.searchParams.set('latitude', location.latitude.toString());
+    url.searchParams.set('longitude', location.longitude.toString());
+    url.searchParams.set('current', 'temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,relative_humidity_2m,surface_pressure,precipitation');
+    url.searchParams.set('timezone', 'auto');
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      throw new Error(`Weather API error: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return {
+      time: data.current.time,
+      temperature: data.current.temperature_2m,
+      weatherCode: data.current.weather_code,
+      windSpeed: data.current.wind_speed_10m,
+      windDirection: data.current.wind_direction_10m,
+      humidity: data.current.relative_humidity_2m,
+      pressure: data.current.surface_pressure,
+      precipitation: data.current.precipitation,
+    };
+  }
+
+  async getHourlyForecast(location: WeatherLocation = DEFAULT_LOCATION, hours: number = 24): Promise<HourlyWeather> {
+    const url = new URL(this.baseUrl);
+    url.searchParams.set('latitude', location.latitude.toString());
+    url.searchParams.set('longitude', location.longitude.toString());
+    url.searchParams.set('hourly', 'temperature_2m,weather_code,precipitation,wind_speed_10m,relative_humidity_2m');
+    url.searchParams.set('timezone', 'auto');
+    url.searchParams.set('forecast_hours', hours.toString());
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      throw new Error(`Weather API error: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return {
+      time: data.hourly.time.slice(0, hours),
+      temperature: data.hourly.temperature_2m.slice(0, hours),
+      weatherCode: data.hourly.weather_code.slice(0, hours),
+      precipitation: data.hourly.precipitation.slice(0, hours),
+      windSpeed: data.hourly.wind_speed_10m.slice(0, hours),
+      humidity: data.hourly.relative_humidity_2m.slice(0, hours),
+    };
+  }
+
+  async getDailyForecast(location: WeatherLocation = DEFAULT_LOCATION, days: number = 7): Promise<DailyWeather> {
+    const url = new URL(this.baseUrl);
+    url.searchParams.set('latitude', location.latitude.toString());
+    url.searchParams.set('longitude', location.longitude.toString());
+    url.searchParams.set('daily', 'temperature_2m_max,temperature_2m_min,weather_code,precipitation_sum,wind_speed_10m_max,sunrise,sunset');
+    url.searchParams.set('timezone', 'auto');
+    url.searchParams.set('forecast_days', days.toString());
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      throw new Error(`Weather API error: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return {
+      time: data.daily.time.slice(0, days),
+      temperatureMax: data.daily.temperature_2m_max.slice(0, days),
+      temperatureMin: data.daily.temperature_2m_min.slice(0, days),
+      weatherCode: data.daily.weather_code.slice(0, days),
+      precipitationSum: data.daily.precipitation_sum.slice(0, days),
+      windSpeedMax: data.daily.wind_speed_10m_max.slice(0, days),
+      sunrise: data.daily.sunrise.slice(0, days),
+      sunset: data.daily.sunset.slice(0, days),
+    };
+  }
+
+  async getCompleteWeatherData(location: WeatherLocation = DEFAULT_LOCATION): Promise<WeatherData> {
+    const [current, hourly, daily] = await Promise.all([
+      this.getCurrentWeather(location),
+      this.getHourlyForecast(location, 24),
+      this.getDailyForecast(location, 7),
+    ]);
+
+    return {
+      current,
+      hourly,
+      daily,
+      location,
+    };
+  }
+
+  getWeatherDescription(weatherCode: number): { description: string; icon: string } {
+    return WEATHER_CODES[weatherCode] || { description: 'Unknown', icon: '❓' };
+  }
+}
+
+export const weatherAPI = new WeatherAPIService();

--- a/src/pages/weather-dashboard/services/weather-api.ts
+++ b/src/pages/weather-dashboard/services/weather-api.ts
@@ -80,7 +80,7 @@ export const WEATHER_CODES: Record<number, { description: string; icon: string }
 // Default location (New York City)
 export const DEFAULT_LOCATION: WeatherLocation = {
   latitude: 40.7128,
-  longitude: -74.0060,
+  longitude: -74.006,
   name: 'New York City',
 };
 
@@ -91,7 +91,10 @@ export class WeatherAPIService {
     const url = new URL(this.baseUrl);
     url.searchParams.set('latitude', location.latitude.toString());
     url.searchParams.set('longitude', location.longitude.toString());
-    url.searchParams.set('current', 'temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,relative_humidity_2m,surface_pressure,precipitation');
+    url.searchParams.set(
+      'current',
+      'temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,relative_humidity_2m,surface_pressure,precipitation',
+    );
     url.searchParams.set('timezone', 'auto');
 
     const response = await fetch(url.toString());
@@ -140,7 +143,10 @@ export class WeatherAPIService {
     const url = new URL(this.baseUrl);
     url.searchParams.set('latitude', location.latitude.toString());
     url.searchParams.set('longitude', location.longitude.toString());
-    url.searchParams.set('daily', 'temperature_2m_max,temperature_2m_min,weather_code,precipitation_sum,wind_speed_10m_max,sunrise,sunset');
+    url.searchParams.set(
+      'daily',
+      'temperature_2m_max,temperature_2m_min,weather_code,precipitation_sum,wind_speed_10m_max,sunrise,sunset',
+    );
     url.searchParams.set('timezone', 'auto');
     url.searchParams.set('forecast_days', days.toString());
 

--- a/src/pages/weather-dashboard/styles/daily-forecast.scss
+++ b/src/pages/weather-dashboard/styles/daily-forecast.scss
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.daily-forecast-container {
+  overflow-x: auto;
+  padding-bottom: 16px;
+  
+  /* Custom scrollbar styling */
+  &::-webkit-scrollbar {
+    height: 8px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 4px;
+  }
+  
+  &::-webkit-scrollbar-thumb:hover {
+    background: #a8a8a8;
+  }
+}
+
+.daily-forecast-grid {
+  display: flex;
+  gap: 16px;
+  min-width: max-content;
+  padding: 4px;
+}
+
+.daily-forecast-card {
+  min-width: 200px;
+  max-width: 200px;
+  border: 1px solid #e0e5e8;
+  border-radius: 8px;
+  padding: 16px;
+  background-color: #ffffff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  }
+}
+
+@media (max-width: 768px) {
+  .daily-forecast-card {
+    min-width: 160px;
+    max-width: 160px;
+    padding: 12px;
+  }
+}

--- a/src/pages/weather-dashboard/styles/daily-forecast.scss
+++ b/src/pages/weather-dashboard/styles/daily-forecast.scss
@@ -4,22 +4,22 @@
 .daily-forecast-container {
   overflow-x: auto;
   padding-bottom: 16px;
-  
+
   /* Custom scrollbar styling */
   &::-webkit-scrollbar {
     height: 8px;
   }
-  
+
   &::-webkit-scrollbar-track {
     background: #f1f1f1;
     border-radius: 4px;
   }
-  
+
   &::-webkit-scrollbar-thumb {
     background: #c1c1c1;
     border-radius: 4px;
   }
-  
+
   &::-webkit-scrollbar-thumb:hover {
     background: #a8a8a8;
   }
@@ -40,8 +40,10 @@
   padding: 16px;
   background-color: #ffffff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  
+  transition:
+    transform 0.2s ease-in-out,
+    box-shadow 0.2s ease-in-out;
+
   &:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);

--- a/src/pages/weather-dashboard/widgets/current-weather-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/current-weather-widget.tsx
@@ -22,17 +22,14 @@ export function CurrentWeatherWidget({ data, location }: CurrentWeatherWidgetPro
   const lastUpdated = new Date(data.time).toLocaleTimeString();
 
   return (
-    <Container
-      header={
-        <Header description={`Last updated: ${lastUpdated}`}>
-          Current Weather - {location.name}
-        </Header>
-      }
-    >
+    <Container header={<Header description={`Last updated: ${lastUpdated}`}>Current Weather - {location.name}</Header>}>
       <SpaceBetween size="l">
         <div style={{ textAlign: 'center' }}>
           <Box fontSize="heading-xl" fontWeight="bold" margin={{ bottom: 's' }}>
-            <span style={{ fontSize: '3rem' }}>{Math.round(convertTemperature(data.temperature))}{getUnitSymbol()}</span>
+            <span style={{ fontSize: '3rem' }}>
+              {Math.round(convertTemperature(data.temperature))}
+              {getUnitSymbol()}
+            </span>
           </Box>
           <Box fontSize="heading-m" color="text-body-secondary">
             <span style={{ fontSize: '2rem', marginRight: '8px' }}>{weatherInfo.icon}</span>

--- a/src/pages/weather-dashboard/widgets/current-weather-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/current-weather-widget.tsx
@@ -9,6 +9,7 @@ import Box from '@cloudscape-design/components/box';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 
 import { CurrentWeather, WeatherLocation, weatherAPI } from '../services/weather-api';
+import { useTemperatureUnit } from '../context/temperature-unit-context';
 
 interface CurrentWeatherWidgetProps {
   data: CurrentWeather;
@@ -16,6 +17,7 @@ interface CurrentWeatherWidgetProps {
 }
 
 export function CurrentWeatherWidget({ data, location }: CurrentWeatherWidgetProps) {
+  const { convertTemperature, getUnitSymbol } = useTemperatureUnit();
   const weatherInfo = weatherAPI.getWeatherDescription(data.weatherCode);
   const lastUpdated = new Date(data.time).toLocaleTimeString();
 
@@ -30,7 +32,7 @@ export function CurrentWeatherWidget({ data, location }: CurrentWeatherWidgetPro
       <SpaceBetween size="l">
         <div style={{ textAlign: 'center' }}>
           <Box fontSize="heading-xl" fontWeight="bold" margin={{ bottom: 's' }}>
-            <span style={{ fontSize: '3rem' }}>{Math.round(data.temperature)}°C</span>
+            <span style={{ fontSize: '3rem' }}>{Math.round(convertTemperature(data.temperature))}{getUnitSymbol()}</span>
           </Box>
           <Box fontSize="heading-m" color="text-body-secondary">
             <span style={{ fontSize: '2rem', marginRight: '8px' }}>{weatherInfo.icon}</span>

--- a/src/pages/weather-dashboard/widgets/current-weather-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/current-weather-widget.tsx
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+
+import { CurrentWeather, WeatherLocation, weatherAPI } from '../services/weather-api';
+
+interface CurrentWeatherWidgetProps {
+  data: CurrentWeather;
+  location: WeatherLocation;
+}
+
+export function CurrentWeatherWidget({ data, location }: CurrentWeatherWidgetProps) {
+  const weatherInfo = weatherAPI.getWeatherDescription(data.weatherCode);
+  const lastUpdated = new Date(data.time).toLocaleTimeString();
+
+  return (
+    <Container
+      header={
+        <Header description={`Last updated: ${lastUpdated}`}>
+          Current Weather - {location.name}
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <div style={{ textAlign: 'center' }}>
+          <Box fontSize="heading-xl" fontWeight="bold" margin={{ bottom: 's' }}>
+            <span style={{ fontSize: '3rem' }}>{Math.round(data.temperature)}°C</span>
+          </Box>
+          <Box fontSize="heading-m" color="text-body-secondary">
+            <span style={{ fontSize: '2rem', marginRight: '8px' }}>{weatherInfo.icon}</span>
+            {weatherInfo.description}
+          </Box>
+        </div>
+
+        <ColumnLayout columns={2} variant="text-grid">
+          <div>
+            <Box variant="awsui-key-label">Humidity</Box>
+            <Box fontSize="heading-s">{data.humidity}%</Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Pressure</Box>
+            <Box fontSize="heading-s">{Math.round(data.pressure)} hPa</Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Wind Speed</Box>
+            <Box fontSize="heading-s">{Math.round(data.windSpeed)} km/h</Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Precipitation</Box>
+            <Box fontSize="heading-s">{data.precipitation} mm</Box>
+          </div>
+        </ColumnLayout>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
@@ -42,21 +42,17 @@ export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
   });
 
   return (
-    <Container
-      header={
-        <Header description="8-day weather forecast">
-          Daily Forecast
-        </Header>
-      }
-    >
+    <Container header={<Header description="8-day weather forecast">Daily Forecast</Header>}>
       <div className="daily-forecast-container">
         <div className="daily-forecast-grid">
-          {cardItems.map((item) => (
+          {cardItems.map(item => (
             <div key={item.id} className="daily-forecast-card">
               <SpaceBetween direction="vertical" size="s">
                 <div style={{ textAlign: 'center' }}>
                   <Box variant="h3">{item.dayName}</Box>
-                  <Box variant="small" color="text-body-secondary">{item.monthDay}</Box>
+                  <Box variant="small" color="text-body-secondary">
+                    {item.monthDay}
+                  </Box>
                 </div>
 
                 <div style={{ textAlign: 'center' }}>
@@ -66,8 +62,14 @@ export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
 
                 <div style={{ textAlign: 'center' }}>
                   <Box fontSize="heading-m">
-                    <span style={{ fontWeight: 'bold' }}>{item.tempMax}{getUnitSymbol()}</span>
-                    <span style={{ color: '#687078', marginLeft: '8px' }}>{item.tempMin}{getUnitSymbol()}</span>
+                    <span style={{ fontWeight: 'bold' }}>
+                      {item.tempMax}
+                      {getUnitSymbol()}
+                    </span>
+                    <span style={{ color: '#687078', marginLeft: '8px' }}>
+                      {item.tempMin}
+                      {getUnitSymbol()}
+                    </span>
                   </Box>
                 </div>
 

--- a/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Cards from '@cloudscape-design/components/cards';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+
+import { DailyWeather, weatherAPI } from '../services/weather-api';
+
+interface DailyForecastWidgetProps {
+  data: DailyWeather;
+}
+
+export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
+  const cardItems = data.time.slice(0, 5).map((time, index) => {
+    const weatherInfo = weatherAPI.getWeatherDescription(data.weatherCode[index]);
+    const date = new Date(time);
+    const dayName = date.toLocaleDateString([], { weekday: 'short' });
+    const monthDay = date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+    
+    return {
+      id: index,
+      dayName,
+      monthDay,
+      weather: weatherInfo,
+      tempMax: Math.round(data.temperatureMax[index]),
+      tempMin: Math.round(data.temperatureMin[index]),
+      precipitation: data.precipitationSum[index],
+      windSpeed: Math.round(data.windSpeedMax[index]),
+      sunrise: new Date(data.sunrise[index]).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      sunset: new Date(data.sunset[index]).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    };
+  });
+
+  return (
+    <Container
+      header={
+        <Header description="5-day weather forecast">
+          Daily Forecast
+        </Header>
+      }
+    >
+      <Cards
+        ariaLabels={{
+          itemSelectionLabel: (e, n) => `select ${n.dayName}`,
+          selectionGroupLabel: 'Daily forecast selection',
+        }}
+        cardDefinition={{
+          header: item => (
+            <SpaceBetween direction="vertical" size="xs">
+              <Box variant="h3">{item.dayName}</Box>
+              <Box variant="small" color="text-body-secondary">{item.monthDay}</Box>
+            </SpaceBetween>
+          ),
+          sections: [
+            {
+              id: 'weather',
+              content: item => (
+                <div style={{ textAlign: 'center', marginBottom: '16px' }}>
+                  <div style={{ fontSize: '3rem', marginBottom: '8px' }}>{item.weather.icon}</div>
+                  <Box variant="small">{item.weather.description}</Box>
+                </div>
+              ),
+            },
+            {
+              id: 'temperature',
+              content: item => (
+                <div style={{ textAlign: 'center', marginBottom: '16px' }}>
+                  <Box fontSize="heading-l">
+                    <span style={{ fontWeight: 'bold' }}>{item.tempMax}°</span>
+                    <span style={{ color: '#687078', marginLeft: '8px' }}>{item.tempMin}°</span>
+                  </Box>
+                </div>
+              ),
+            },
+            {
+              id: 'details',
+              content: item => (
+                <ColumnLayout columns={2} variant="text-grid">
+                  <div>
+                    <Box variant="awsui-key-label">Precip</Box>
+                    <Box fontSize="body-s">{item.precipitation}mm</Box>
+                  </div>
+                  <div>
+                    <Box variant="awsui-key-label">Wind</Box>
+                    <Box fontSize="body-s">{item.windSpeed}km/h</Box>
+                  </div>
+                  <div>
+                    <Box variant="awsui-key-label">Sunrise</Box>
+                    <Box fontSize="body-s">{item.sunrise}</Box>
+                  </div>
+                  <div>
+                    <Box variant="awsui-key-label">Sunset</Box>
+                    <Box fontSize="body-s">{item.sunset}</Box>
+                  </div>
+                </ColumnLayout>
+              ),
+            },
+          ],
+        }}
+        cardsPerRow={[
+          { cards: 1, minWidth: 0 },
+          { cards: 2, minWidth: 500 },
+          { cards: 3, minWidth: 800 },
+          { cards: 5, minWidth: 1200 },
+        ]}
+        items={cardItems}
+        trackBy="id"
+        visibleSections={['weather', 'temperature', 'details']}
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
@@ -10,25 +10,28 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 
 import { DailyWeather, weatherAPI } from '../services/weather-api';
+import { useTemperatureUnit } from '../context/temperature-unit-context';
 
 interface DailyForecastWidgetProps {
   data: DailyWeather;
 }
 
 export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
-  const cardItems = data.time.slice(0, 5).map((time, index) => {
+  const { convertTemperature, getUnitSymbol } = useTemperatureUnit();
+
+  const cardItems = data.time.slice(0, 7).map((time, index) => {
     const weatherInfo = weatherAPI.getWeatherDescription(data.weatherCode[index]);
     const date = new Date(time);
     const dayName = date.toLocaleDateString([], { weekday: 'short' });
     const monthDay = date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-    
+
     return {
       id: index,
       dayName,
       monthDay,
       weather: weatherInfo,
-      tempMax: Math.round(data.temperatureMax[index]),
-      tempMin: Math.round(data.temperatureMin[index]),
+      tempMax: Math.round(convertTemperature(data.temperatureMax[index])),
+      tempMin: Math.round(convertTemperature(data.temperatureMin[index])),
       precipitation: data.precipitationSum[index],
       windSpeed: Math.round(data.windSpeedMax[index]),
       sunrise: new Date(data.sunrise[index]).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
@@ -39,47 +42,44 @@ export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
   return (
     <Container
       header={
-        <Header description="5-day weather forecast">
+        <Header description="7-day weather forecast">
           Daily Forecast
         </Header>
       }
     >
-      <Cards
-        ariaLabels={{
-          itemSelectionLabel: (e, n) => `select ${n.dayName}`,
-          selectionGroupLabel: 'Daily forecast selection',
-        }}
-        cardDefinition={{
-          header: item => (
-            <SpaceBetween direction="vertical" size="xs">
-              <Box variant="h3">{item.dayName}</Box>
-              <Box variant="small" color="text-body-secondary">{item.monthDay}</Box>
-            </SpaceBetween>
-          ),
-          sections: [
-            {
-              id: 'weather',
-              content: item => (
-                <div style={{ textAlign: 'center', marginBottom: '16px' }}>
-                  <div style={{ fontSize: '3rem', marginBottom: '8px' }}>{item.weather.icon}</div>
+      <div style={{ overflowX: 'auto', paddingBottom: '16px' }}>
+        <div style={{ display: 'flex', gap: '16px', minWidth: 'max-content' }}>
+          {cardItems.map((item) => (
+            <div
+              key={item.id}
+              style={{
+                minWidth: '200px',
+                maxWidth: '200px',
+                border: '1px solid #e0e5e8',
+                borderRadius: '8px',
+                padding: '16px',
+                backgroundColor: '#ffffff',
+                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+              }}
+            >
+              <SpaceBetween direction="vertical" size="s">
+                <div style={{ textAlign: 'center' }}>
+                  <Box variant="h3">{item.dayName}</Box>
+                  <Box variant="small" color="text-body-secondary">{item.monthDay}</Box>
+                </div>
+
+                <div style={{ textAlign: 'center' }}>
+                  <div style={{ fontSize: '2.5rem', marginBottom: '8px' }}>{item.weather.icon}</div>
                   <Box variant="small">{item.weather.description}</Box>
                 </div>
-              ),
-            },
-            {
-              id: 'temperature',
-              content: item => (
-                <div style={{ textAlign: 'center', marginBottom: '16px' }}>
-                  <Box fontSize="heading-l">
-                    <span style={{ fontWeight: 'bold' }}>{item.tempMax}°</span>
-                    <span style={{ color: '#687078', marginLeft: '8px' }}>{item.tempMin}°</span>
+
+                <div style={{ textAlign: 'center' }}>
+                  <Box fontSize="heading-m">
+                    <span style={{ fontWeight: 'bold' }}>{item.tempMax}{getUnitSymbol()}</span>
+                    <span style={{ color: '#687078', marginLeft: '8px' }}>{item.tempMin}{getUnitSymbol()}</span>
                   </Box>
                 </div>
-              ),
-            },
-            {
-              id: 'details',
-              content: item => (
+
                 <ColumnLayout columns={2} variant="text-grid">
                   <div>
                     <Box variant="awsui-key-label">Precip</Box>
@@ -98,20 +98,11 @@ export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
                     <Box fontSize="body-s">{item.sunset}</Box>
                   </div>
                 </ColumnLayout>
-              ),
-            },
-          ],
-        }}
-        cardsPerRow={[
-          { cards: 1, minWidth: 0 },
-          { cards: 2, minWidth: 500 },
-          { cards: 3, minWidth: 800 },
-          { cards: 5, minWidth: 1200 },
-        ]}
-        items={cardItems}
-        trackBy="id"
-        visibleSections={['weather', 'temperature', 'details']}
-      />
+              </SpaceBetween>
+            </div>
+          ))}
+        </div>
+      </div>
     </Container>
   );
 }

--- a/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
@@ -21,7 +21,7 @@ interface DailyForecastWidgetProps {
 export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
   const { convertTemperature, getUnitSymbol } = useTemperatureUnit();
 
-  const cardItems = data.time.slice(0, 7).map((time, index) => {
+  const cardItems = data.time.slice(0, 8).map((time, index) => {
     const weatherInfo = weatherAPI.getWeatherDescription(data.weatherCode[index]);
     const date = new Date(time);
     const dayName = date.toLocaleDateString([], { weekday: 'short' });
@@ -44,7 +44,7 @@ export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
   return (
     <Container
       header={
-        <Header description="7-day weather forecast">
+        <Header description="8-day weather forecast">
           Daily Forecast
         </Header>
       }

--- a/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/daily-forecast-widget.tsx
@@ -12,6 +12,8 @@ import ColumnLayout from '@cloudscape-design/components/column-layout';
 import { DailyWeather, weatherAPI } from '../services/weather-api';
 import { useTemperatureUnit } from '../context/temperature-unit-context';
 
+import '../styles/daily-forecast.scss';
+
 interface DailyForecastWidgetProps {
   data: DailyWeather;
 }
@@ -47,21 +49,10 @@ export function DailyForecastWidget({ data }: DailyForecastWidgetProps) {
         </Header>
       }
     >
-      <div style={{ overflowX: 'auto', paddingBottom: '16px' }}>
-        <div style={{ display: 'flex', gap: '16px', minWidth: 'max-content' }}>
+      <div className="daily-forecast-container">
+        <div className="daily-forecast-grid">
           {cardItems.map((item) => (
-            <div
-              key={item.id}
-              style={{
-                minWidth: '200px',
-                maxWidth: '200px',
-                border: '1px solid #e0e5e8',
-                borderRadius: '8px',
-                padding: '16px',
-                backgroundColor: '#ffffff',
-                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
-              }}
-            >
+            <div key={item.id} className="daily-forecast-card">
               <SpaceBetween direction="vertical" size="s">
                 <div style={{ textAlign: 'center' }}>
                   <Box variant="h3">{item.dayName}</Box>

--- a/src/pages/weather-dashboard/widgets/hourly-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/hourly-forecast-widget.tsx
@@ -30,13 +30,7 @@ export function HourlyForecastWidget({ data }: HourlyForecastWidgetProps) {
   });
 
   return (
-    <Container
-      header={
-        <Header description="Next 8 hours detailed forecast">
-          Hourly Forecast
-        </Header>
-      }
-    >
+    <Container header={<Header description="Next 8 hours detailed forecast">Hourly Forecast</Header>}>
       <Table
         columnDefinitions={[
           {

--- a/src/pages/weather-dashboard/widgets/hourly-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/hourly-forecast-widget.tsx
@@ -8,17 +8,20 @@ import Table from '@cloudscape-design/components/table';
 import Box from '@cloudscape-design/components/box';
 
 import { HourlyWeather, weatherAPI } from '../services/weather-api';
+import { useTemperatureUnit } from '../context/temperature-unit-context';
 
 interface HourlyForecastWidgetProps {
   data: HourlyWeather;
 }
 
 export function HourlyForecastWidget({ data }: HourlyForecastWidgetProps) {
+  const { convertTemperature, getUnitSymbol } = useTemperatureUnit();
+
   const tableItems = data.time.slice(0, 8).map((time, index) => {
     const weatherInfo = weatherAPI.getWeatherDescription(data.weatherCode[index]);
     return {
       time: new Date(time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      temperature: Math.round(data.temperature[index]),
+      temperature: Math.round(convertTemperature(data.temperature[index])),
       weather: weatherInfo,
       precipitation: data.precipitation[index],
       humidity: data.humidity[index],
@@ -55,7 +58,7 @@ export function HourlyForecastWidget({ data }: HourlyForecastWidgetProps) {
           {
             id: 'temperature',
             header: 'Temp',
-            cell: item => `${item.temperature}°C`,
+            cell: item => `${item.temperature}${getUnitSymbol()}`,
           },
           {
             id: 'precipitation',

--- a/src/pages/weather-dashboard/widgets/hourly-forecast-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/hourly-forecast-widget.tsx
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+
+import { HourlyWeather, weatherAPI } from '../services/weather-api';
+
+interface HourlyForecastWidgetProps {
+  data: HourlyWeather;
+}
+
+export function HourlyForecastWidget({ data }: HourlyForecastWidgetProps) {
+  const tableItems = data.time.slice(0, 8).map((time, index) => {
+    const weatherInfo = weatherAPI.getWeatherDescription(data.weatherCode[index]);
+    return {
+      time: new Date(time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      temperature: Math.round(data.temperature[index]),
+      weather: weatherInfo,
+      precipitation: data.precipitation[index],
+      humidity: data.humidity[index],
+      windSpeed: Math.round(data.windSpeed[index]),
+    };
+  });
+
+  return (
+    <Container
+      header={
+        <Header description="Next 8 hours detailed forecast">
+          Hourly Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'time',
+            header: 'Time',
+            cell: item => item.time,
+            sortingField: 'time',
+          },
+          {
+            id: 'weather',
+            header: 'Conditions',
+            cell: item => (
+              <Box>
+                <span style={{ marginRight: '8px' }}>{item.weather.icon}</span>
+                {item.weather.description}
+              </Box>
+            ),
+          },
+          {
+            id: 'temperature',
+            header: 'Temp',
+            cell: item => `${item.temperature}°C`,
+          },
+          {
+            id: 'precipitation',
+            header: 'Precip',
+            cell: item => `${item.precipitation}mm`,
+          },
+          {
+            id: 'humidity',
+            header: 'Humidity',
+            cell: item => `${item.humidity}%`,
+          },
+          {
+            id: 'windSpeed',
+            header: 'Wind',
+            cell: item => `${item.windSpeed}km/h`,
+          },
+        ]}
+        items={tableItems}
+        variant="borderless"
+        wrapLines
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/widgets/index.ts
+++ b/src/pages/weather-dashboard/widgets/index.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export { CurrentWeatherWidget } from './current-weather-widget';
+export { HourlyForecastWidget } from './hourly-forecast-widget';
+export { DailyForecastWidget } from './daily-forecast-widget';
+export { TemperatureChartWidget } from './temperature-chart-widget';
+export { PrecipitationWidget } from './precipitation-widget';
+export { WindWidget } from './wind-widget';

--- a/src/pages/weather-dashboard/widgets/precipitation-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/precipitation-widget.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import BarChart from '@cloudscape-design/components/bar-chart';
+
+import { HourlyWeather } from '../services/weather-api';
+
+interface PrecipitationWidgetProps {
+  data: HourlyWeather;
+}
+
+export function PrecipitationWidget({ data }: PrecipitationWidgetProps) {
+  const chartData = data.time.slice(0, 12).map((time, index) => ({
+    x: new Date(time).toLocaleTimeString([], { hour: '2-digit' }),
+    y: data.precipitation[index],
+  }));
+
+  const maxPrecipitation = Math.max(...data.precipitation.slice(0, 12));
+
+  return (
+    <Container
+      header={
+        <Header description="Next 12 hours precipitation forecast">
+          Precipitation
+        </Header>
+      }
+    >
+      <BarChart
+        series={[
+          {
+            title: 'Precipitation',
+            type: 'bar',
+            data: chartData,
+            valueFormatter: (value) => `${value}mm`,
+          },
+        ]}
+        xTitle="Time"
+        yTitle="Precipitation (mm)"
+        height={250}
+        hideFilter
+        hideLegend
+        yDomain={[0, Math.max(maxPrecipitation * 1.1, 1)]}
+        emphasizeBaselineAxis={false}
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/widgets/precipitation-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/precipitation-widget.tsx
@@ -21,20 +21,14 @@ export function PrecipitationWidget({ data }: PrecipitationWidgetProps) {
   const maxPrecipitation = Math.max(...data.precipitation.slice(0, 12));
 
   return (
-    <Container
-      header={
-        <Header description="Next 12 hours precipitation forecast">
-          Precipitation
-        </Header>
-      }
-    >
+    <Container header={<Header description="Next 12 hours precipitation forecast">Precipitation</Header>}>
       <BarChart
         series={[
           {
             title: 'Precipitation',
             type: 'bar',
             data: chartData,
-            valueFormatter: (value) => `${value}mm`,
+            valueFormatter: value => `${value}mm`,
           },
         ]}
         xTitle="Time"

--- a/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
@@ -40,11 +40,11 @@ export function TemperatureChartWidget({ data }: TemperatureChartWidgetProps) {
         ]}
         xDomain={[chartData[0]?.x, chartData[chartData.length - 1]?.x]}
         yDomain={[
-          Math.min(...data.temperature.slice(0, 12)) - 2,
-          Math.max(...data.temperature.slice(0, 12)) + 2,
+          Math.min(...chartData.map(d => d.y)) - 2,
+          Math.max(...chartData.map(d => d.y)) + 2,
         ]}
         xTitle="Time"
-        yTitle="Temperature (°C)"
+        yTitle={`Temperature (${getUnitSymbol()})`}
         height={300}
         hideFilter
         hideLegend

--- a/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
@@ -7,15 +7,18 @@ import Header from '@cloudscape-design/components/header';
 import LineChart from '@cloudscape-design/components/line-chart';
 
 import { HourlyWeather } from '../services/weather-api';
+import { useTemperatureUnit } from '../context/temperature-unit-context';
 
 interface TemperatureChartWidgetProps {
   data: HourlyWeather;
 }
 
 export function TemperatureChartWidget({ data }: TemperatureChartWidgetProps) {
+  const { convertTemperature, getUnitSymbol } = useTemperatureUnit();
+
   const chartData = data.time.slice(0, 12).map((time, index) => ({
     x: new Date(time),
-    y: data.temperature[index],
+    y: convertTemperature(data.temperature[index]),
   }));
 
   return (
@@ -32,7 +35,7 @@ export function TemperatureChartWidget({ data }: TemperatureChartWidgetProps) {
             title: 'Temperature',
             type: 'line',
             data: chartData,
-            valueFormatter: (value) => `${Math.round(value)}°C`,
+            valueFormatter: (value) => `${Math.round(value)}${getUnitSymbol()}`,
           },
         ]}
         xDomain={[chartData[0]?.x, chartData[chartData.length - 1]?.x]}

--- a/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import LineChart from '@cloudscape-design/components/line-chart';
+
+import { HourlyWeather } from '../services/weather-api';
+
+interface TemperatureChartWidgetProps {
+  data: HourlyWeather;
+}
+
+export function TemperatureChartWidget({ data }: TemperatureChartWidgetProps) {
+  const chartData = data.time.slice(0, 12).map((time, index) => ({
+    x: new Date(time),
+    y: data.temperature[index],
+  }));
+
+  return (
+    <Container
+      header={
+        <Header description="Next 12 hours temperature trend">
+          Temperature Trend
+        </Header>
+      }
+    >
+      <LineChart
+        series={[
+          {
+            title: 'Temperature',
+            type: 'line',
+            data: chartData,
+            valueFormatter: (value) => `${Math.round(value)}°C`,
+          },
+        ]}
+        xDomain={[chartData[0]?.x, chartData[chartData.length - 1]?.x]}
+        yDomain={[
+          Math.min(...data.temperature.slice(0, 12)) - 2,
+          Math.max(...data.temperature.slice(0, 12)) + 2,
+        ]}
+        xTitle="Time"
+        yTitle="Temperature (°C)"
+        height={300}
+        hideFilter
+        hideLegend
+        xScaleType="time"
+        emphasizeBaselineAxis={false}
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/temperature-chart-widget.tsx
@@ -22,27 +22,18 @@ export function TemperatureChartWidget({ data }: TemperatureChartWidgetProps) {
   }));
 
   return (
-    <Container
-      header={
-        <Header description="Next 12 hours temperature trend">
-          Temperature Trend
-        </Header>
-      }
-    >
+    <Container header={<Header description="Next 12 hours temperature trend">Temperature Trend</Header>}>
       <LineChart
         series={[
           {
             title: 'Temperature',
             type: 'line',
             data: chartData,
-            valueFormatter: (value) => `${Math.round(value)}${getUnitSymbol()}`,
+            valueFormatter: value => `${Math.round(value)}${getUnitSymbol()}`,
           },
         ]}
         xDomain={[chartData[0]?.x, chartData[chartData.length - 1]?.x]}
-        yDomain={[
-          Math.min(...chartData.map(d => d.y)) - 2,
-          Math.max(...chartData.map(d => d.y)) + 2,
-        ]}
+        yDomain={[Math.min(...chartData.map(d => d.y)) - 2, Math.max(...chartData.map(d => d.y)) + 2]}
         xTitle="Time"
         yTitle={`Temperature (${getUnitSymbol()})`}
         height={300}

--- a/src/pages/weather-dashboard/widgets/wind-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/wind-widget.tsx
@@ -17,7 +17,24 @@ interface WindWidgetProps {
 }
 
 function getWindDirection(degrees: number): string {
-  const directions = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW'];
+  const directions = [
+    'N',
+    'NNE',
+    'NE',
+    'ENE',
+    'E',
+    'ESE',
+    'SE',
+    'SSE',
+    'S',
+    'SSW',
+    'SW',
+    'WSW',
+    'W',
+    'WNW',
+    'NW',
+    'NNW',
+  ];
   const index = Math.round(degrees / 22.5) % 16;
   return directions[index];
 }
@@ -33,22 +50,14 @@ export function WindWidget({ current, hourly }: WindWidgetProps) {
   const currentWindCategory = getWindSpeedCategory(current.windSpeed);
   const avgWindSpeed = hourly.windSpeed.slice(0, 12).reduce((a, b) => a + b, 0) / 12;
   const maxWindSpeed = Math.max(...hourly.windSpeed.slice(0, 12));
-  
+
   return (
-    <Container
-      header={
-        <Header description="Current wind conditions and 12-hour trend">
-          Wind Information
-        </Header>
-      }
-    >
+    <Container header={<Header description="Current wind conditions and 12-hour trend">Wind Information</Header>}>
       <SpaceBetween size="l">
         <ColumnLayout columns={2} variant="text-grid">
           <div>
             <Box variant="awsui-key-label">Current Speed</Box>
-            <Box fontSize="heading-s">
-              {Math.round(current.windSpeed)} km/h
-            </Box>
+            <Box fontSize="heading-s">{Math.round(current.windSpeed)} km/h</Box>
             <Box variant="small" color={currentWindCategory.color as any}>
               {currentWindCategory.category}
             </Box>
@@ -75,9 +84,7 @@ export function WindWidget({ current, hourly }: WindWidgetProps) {
           />
         </div>
 
-        <div style={{ transform: `rotate(${current.windDirection}deg)`, textAlign: 'center', fontSize: '2rem' }}>
-          ↑
-        </div>
+        <div style={{ transform: `rotate(${current.windDirection}deg)`, textAlign: 'center', fontSize: '2rem' }}>↑</div>
         <Box variant="small" textAlign="center" color="text-body-secondary">
           Wind direction indicator
         </Box>

--- a/src/pages/weather-dashboard/widgets/wind-widget.tsx
+++ b/src/pages/weather-dashboard/widgets/wind-widget.tsx
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import ProgressBar from '@cloudscape-design/components/progress-bar';
+
+import { CurrentWeather, HourlyWeather } from '../services/weather-api';
+
+interface WindWidgetProps {
+  current: CurrentWeather;
+  hourly: HourlyWeather;
+}
+
+function getWindDirection(degrees: number): string {
+  const directions = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW'];
+  const index = Math.round(degrees / 22.5) % 16;
+  return directions[index];
+}
+
+function getWindSpeedCategory(speed: number): { category: string; color: string } {
+  if (speed < 5) return { category: 'Light', color: 'green' };
+  if (speed < 15) return { category: 'Moderate', color: 'blue' };
+  if (speed < 30) return { category: 'Strong', color: 'orange' };
+  return { category: 'Very Strong', color: 'red' };
+}
+
+export function WindWidget({ current, hourly }: WindWidgetProps) {
+  const currentWindCategory = getWindSpeedCategory(current.windSpeed);
+  const avgWindSpeed = hourly.windSpeed.slice(0, 12).reduce((a, b) => a + b, 0) / 12;
+  const maxWindSpeed = Math.max(...hourly.windSpeed.slice(0, 12));
+  
+  return (
+    <Container
+      header={
+        <Header description="Current wind conditions and 12-hour trend">
+          Wind Information
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <ColumnLayout columns={2} variant="text-grid">
+          <div>
+            <Box variant="awsui-key-label">Current Speed</Box>
+            <Box fontSize="heading-s">
+              {Math.round(current.windSpeed)} km/h
+            </Box>
+            <Box variant="small" color={currentWindCategory.color as any}>
+              {currentWindCategory.category}
+            </Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Direction</Box>
+            <Box fontSize="heading-s">
+              {getWindDirection(current.windDirection)} ({Math.round(current.windDirection)}°)
+            </Box>
+          </div>
+        </ColumnLayout>
+
+        <div>
+          <Box variant="awsui-key-label" margin={{ bottom: 's' }}>
+            12-Hour Wind Speed Range
+          </Box>
+          <ProgressBar
+            value={current.windSpeed}
+            additionalInfo={`Average: ${Math.round(avgWindSpeed)} km/h`}
+            description={`Current: ${Math.round(current.windSpeed)} km/h | Max: ${Math.round(maxWindSpeed)} km/h`}
+            label="Wind Speed"
+            resultButtonText="Current"
+            status="success"
+          />
+        </div>
+
+        <div style={{ transform: `rotate(${current.windDirection}deg)`, textAlign: 'center', fontSize: '2rem' }}>
+          ↑
+        </div>
+        <Box variant="small" textAlign="center" color="text-body-secondary">
+          Wind direction indicator
+        </Box>
+      </SpaceBetween>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Purpose

The user requested a new weather dashboard using the Open-Meteo API with specific UI enhancements including a side-scrollable daily forecast and a temperature unit picker (Celsius/Fahrenheit) at the top of the interface.

## Code changes

- **Added weather dashboard route** to main demo index with navigation entry
- **Created complete weather dashboard application** with app layout, header, and side navigation
- **Implemented weather data service** using Open-Meteo API for fetching current, hourly, and daily weather data
- **Built comprehensive widget system** including:
  - Current weather conditions display
  - Hourly forecast table (8-hour view)
  - Daily forecast with side-scroll functionality
  - Temperature trend chart (12-hour)
  - Precipitation bar chart
  - Wind information with direction indicator
- **Added temperature unit context** for Celsius/Fahrenheit conversion throughout the app
- **Created temperature unit picker component** in the header as requested
- **Implemented responsive grid layout** for optimal dashboard viewing across devicesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 42`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/echo-space)

👀 [Preview Link](https://98bf2453a9fe441eb6778cbc07f519aa-echo-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->
<!--<branchName>echo-space</branchName>-->