### PR TITLE
Add styled loading spinner for initial page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -40,7 +40,9 @@
       }
 
       @keyframes spin {
-        to { transform: rotate(360deg); }
+        to {
+          transform: rotate(360deg);
+        }
       }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
       <div id="initial-loader">
         <div class="loader-content">
           <div class="loader-spinner"></div>
-          <div class="loader-text">Loading</div>
+          <div class="loader-text">Loading...</div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,55 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cloudscape Design System Demos</title>
+    <style>
+      #initial-loader {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0f1b2a;
+        z-index: 9999;
+      }
+
+      .loader-content {
+        text-align: center;
+      }
+
+      .loader-spinner {
+        width: 48px;
+        height: 48px;
+        border: 3px solid rgba(5, 115, 209, 0.2);
+        border-top-color: #0972d3;
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+        margin: 0 auto 16px;
+      }
+
+      .loader-text {
+        color: #aab7c4;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+
+      @keyframes spin {
+        to { transform: rotate(360deg); }
+      }
+    </style>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <div id="initial-loader">
+        <div class="loader-content">
+          <div class="loader-spinner"></div>
+          <div class="loader-text">Loading Cloudscape Demos</div>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
-</html> 
+</html>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        background: #0f1b2a;
+        background: #ffffff;
         z-index: 9999;
       }
 
@@ -33,8 +33,8 @@
       }
 
       .loader-text {
-        color: #aab7c4;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+        color: #545b64;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
         font-size: 14px;
         font-weight: 400;
       }

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
       <div id="initial-loader">
         <div class="loader-content">
           <div class="loader-spinner"></div>
-          <div class="loader-text">Loading Cloudscape Demos</div>
+          <div class="loader-text">Loading</div>
         </div>
       </div>
     </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -45,7 +45,7 @@ function LoadingSpinner() {
             fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
           }}
         >
-          Loading
+          Loading...
         </div>
       </div>
     </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,8 +10,49 @@ import * as FakeServer from './fake-server';
 // @ts-expect-error Global FakeServer assignment
 window.FakeServer = Object.assign({}, FakeServer);
 
+function LoadingSpinner() {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#0f1b2a',
+      }}
+    >
+      <div style={{ textAlign: 'center' }}>
+        <div
+          style={{
+            width: '48px',
+            height: '48px',
+            border: '3px solid rgba(5, 115, 209, 0.2)',
+            borderTopColor: '#0972d3',
+            borderRadius: '50%',
+            animation: 'spin 0.8s linear infinite',
+            margin: '0 auto 16px',
+          }}
+        />
+        <div
+          style={{
+            color: '#aab7c4',
+            fontSize: '14px',
+            fontWeight: 400,
+          }}
+        >
+          Loading Cloudscape Demos
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function App() {
-  return <Suspense fallback={<div>Loading...</div>}>{useRoutes(routes)}</Suspense>;
+  return <Suspense fallback={<LoadingSpinner />}>{useRoutes(routes)}</Suspense>;
 }
 
 ReactDOM.createRoot(document.getElementById('app')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,7 +22,7 @@ function LoadingSpinner() {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: '#0f1b2a',
+        background: '#ffffff',
       }}
     >
       <div style={{ textAlign: 'center' }}>
@@ -39,9 +39,10 @@ function LoadingSpinner() {
         />
         <div
           style={{
-            color: '#aab7c4',
+            color: '#545b64',
             fontSize: '14px',
             fontWeight: 400,
+            fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
           }}
         >
           Loading Cloudscape Demos

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -45,7 +45,7 @@ function LoadingSpinner() {
             fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
           }}
         >
-          Loading Cloudscape Demos
+          Loading
         </div>
       </div>
     </div>

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: MIT-0
 @use '@cloudscape-design/design-tokens' as cs;
 
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 body {
   background: cs.$color-background-layout-main;
   position: relative;


### PR DESCRIPTION
## Purpose

Replace the broken-looking "Loading..." text that appears before client hydration with a polished loading state. The user wanted a stylized spinner that matches the app's aesthetic with blue colors, white background, and consistent sans-serif font to prevent font snapping issues.

## Code changes

- **index.html**: Added inline CSS for initial loader with blue spinner, white background, and system font stack
- **main.tsx**: Created `LoadingSpinner` component with matching styles for React Suspense fallback
- **base.scss**: Added keyframe animation for spinner rotation
- Updated loader text from "Loading cloudscape demos" to "Loading..." as requested
- Used Cloudscape blue colors (#0972d3) and consistent typography to match app design

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 45`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98bf2453a9fe441eb6778cbc07f519aa/echo-verse-1)

👀 [Preview Link](https://98bf2453a9fe441eb6778cbc07f519aa-echo-verse-1.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98bf2453a9fe441eb6778cbc07f519aa</projectId>-->
<!--<branchName>echo-verse-1</branchName>-->